### PR TITLE
Add support for local Qdrant mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ by passing the `--fastembed-model-name` argument to the server.
 
 The configuration of the server can be also done using environment variables:
 
-- `QDRANT_URL`: URL of the Qdrant server
+- `QDRANT_URL`: URL of the Qdrant server, e.g. `http://localhost:6333`
 - `QDRANT_API_KEY`: API key for the Qdrant server
 - `COLLECTION_NAME`: Name of the collection to use
 - `FASTEMBED_MODEL_NAME`: Name of the FastEmbed model to use
+- `QDRANT_LOCAL_PATH`: Path to the local Qdrant database
+
+You cannot provide `QDRANT_URL` and `QDRANT_LOCAL_PATH` at the same time.
 
 ## License
 

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -9,23 +9,25 @@ class QdrantConnector:
     :param qdrant_api_key: The API key to use for the Qdrant server.
     :param collection_name: The name of the collection to use.
     :param fastembed_model_name: The name of the FastEmbed model to use.
+    :param qdrant_local_path: The path to the storage directory for the Qdrant client, if local mode is used.
     """
 
     def __init__(
         self,
-        qdrant_url: str,
+        qdrant_url: Optional[str],
         qdrant_api_key: Optional[str],
         collection_name: str,
         fastembed_model_name: str,
+        qdrant_local_path: Optional[str] = None,
     ):
-        self._qdrant_url = qdrant_url.rstrip("/")
+        self._qdrant_url = qdrant_url.rstrip("/") if qdrant_url else None
         self._qdrant_api_key = qdrant_api_key
         self._collection_name = collection_name
         self._fastembed_model_name = fastembed_model_name
         # For the time being, FastEmbed models are the only supported ones.
         # A list of all available models can be found here:
         # https://qdrant.github.io/fastembed/examples/Supported_Models/
-        self._client = AsyncQdrantClient(qdrant_url, api_key=qdrant_api_key)
+        self._client = AsyncQdrantClient(location=qdrant_url, api_key=qdrant_api_key, path=qdrant_local_path)
         self._client.set_model(fastembed_model_name)
 
     async def store_memory(self, information: str):


### PR DESCRIPTION
This PR extends the integration to allow running a local mode of Qdrant Python SDK. That might be enough in some cases, and was requested in https://github.com/qdrant/mcp-server-qdrant/issues/1.