### PR TITLE
Fix compatibility with the previous versions

### DIFF
--- a/src/mcp_server_qdrant/embeddings/base.py
+++ b/src/mcp_server_qdrant/embeddings/base.py
@@ -14,3 +14,8 @@ class EmbeddingProvider(ABC):
     async def embed_query(self, query: str) -> List[float]:
         """Embed a query into a vector."""
         pass
+
+    @abstractmethod
+    def get_vector_name(self) -> str:
+        """Get the name of the vector for the Qdrant collection."""
+        pass

--- a/src/mcp_server_qdrant/embeddings/fastembed.py
+++ b/src/mcp_server_qdrant/embeddings/fastembed.py
@@ -35,3 +35,11 @@ class FastEmbedProvider(EmbeddingProvider):
             None, lambda: list(self.embedding_model.query_embed([query]))
         )
         return embeddings[0].tolist()
+
+    def get_vector_name(self) -> str:
+        """
+        Return the name of the vector for the Qdrant collection.
+        Important: This is compatible with the FastEmbed logic used before 0.6.0.
+        """
+        model_name = self.embedding_model.model_name.split("/")[-1].lower()
+        return f"fast-{model_name}"

--- a/uv.lock
+++ b/uv.lock
@@ -118,14 +118,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.7"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR fixes the backward compatibility with 0.5.2, allowing to pass `--fastembed-model-name` parameter.