### PR TITLE
Refactor server and embedding provider to improve modularity

### DIFF
--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -1,18 +1,17 @@
 from mcp_server_qdrant.embeddings import EmbeddingProvider
 
 
-def create_embedding_provider(provider_type: str, **kwargs) -> EmbeddingProvider:
+def create_embedding_provider(provider_type: str, model_name: str) -> EmbeddingProvider:
     """
     Create an embedding provider based on the specified type.
 
     :param provider_type: The type of embedding provider to create.
-    :param kwargs: Additional arguments to pass to the provider constructor.
+    :param model_name: The name of the model to use for embeddings, specific to the provider type.
     :return: An instance of the specified embedding provider.
     """
     if provider_type.lower() == "fastembed":
         from .fastembed import FastEmbedProvider
 
-        model_name = kwargs.get("model_name", "sentence-transformers/all-MiniLM-L6-v2")
         return FastEmbedProvider(model_name)
     else:
         raise ValueError(f"Unsupported embedding provider: {provider_type}")


### PR DESCRIPTION
- Modify `serve()` function to accept a pre-configured QdrantConnector
- Update `create_embedding_provider()` to simplify model name handling
- Improve error handling and parameter passing in server tools
- Restructure main function to create connector and server more explicitly