### PR TITLE
Adding multi collection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The configuration of the server can be also done using environment variables:
 - `QDRANT_LOCAL_PATH`: Path to the local Qdrant database
 - `MULTI_COLLECTION_MODE`: Enable multi-collection mode for AI agents (set to any value to enable)
 - `COLLECTION_PREFIX`: Prefix for all collections in multi-collection mode
-- `PROTECT_COLLECTIONS`: Prevent deletion of memories, use `*` to block all deletion, or specify collection names to make specific collections insert only.
+- `PROTECT_COLLECTIONS`: Comma-separated list of collection names that are protected from deletion operations (insert-only). In multi-collection mode, if specified without values, all collections will be insert-only.
+- `READONLY_COLLECTIONS`: Comma-separated list of collection names that are completely read-only (no insertions or deletions). In multi-collection mode, if specified without values, all collections will be read-only.
 
 You cannot provide `QDRANT_URL` and `QDRANT_LOCAL_PATH` at the same time.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The configuration of the server can be also done using environment variables:
 - `QDRANT_URL`: URL of the Qdrant server, e.g. `http://localhost:6333`
 - `QDRANT_API_KEY`: API key for the Qdrant server
 - `COLLECTION_NAME`: Name of the collection to use, or if in mutli-collection mode, the default collection name.
+  - Note: The `COLLECTION_PREFIX` will not apply to the `COLLECTION_NAME`.
 - `EMBEDDING_MODEL`: Name of the embedding model to use
 - `EMBEDDING_PROVIDER`: Embedding provider to use (currently only "fastembed" is supported)
 - `QDRANT_LOCAL_PATH`: Path to the local Qdrant database

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![smithery badge](https://smithery.ai/badge/mcp-server-qdrant)](https://smithery.ai/protocol/mcp-server-qdrant)
 
-> The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Whether you're building an AI-powered IDE, enhancing a chat interface, or creating custom AI workflows, MCP provides a standardized way to connect LLMs with the context they need.
+> The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. Whether you’re building an AI-powered IDE, enhancing a chat interface, or creating custom AI workflows, MCP provides a standardized way to connect LLMs with the context they need.
 
 This repository is an example of how to create a MCP server for [Qdrant](https://qdrant.tech/), a vector search engine.
 
@@ -22,6 +22,7 @@ It acts as a semantic memory layer on top of the Qdrant database.
    - Input:
      - `information` (string): Memory to store
      - `collection_name` (string, optional): Collection to store the memory in (only in multi-collection mode)
+     - `replace_memory_ids` (string[], optional): Array of memory IDs to remove when inserting this memory.
    - Returns: Confirmation message
 2. `qdrant-find-memories`
    - Retrieve a memory from the Qdrant database
@@ -157,8 +158,6 @@ In multi-collection mode:
 - Collections are automatically created when needed
 - The AI can list available collections and search across all collections
 
-You can also provide a JSON configuration for new collections using the `--collection-config` parameter:
-
 ```json
 {
   "qdrant": {
@@ -169,9 +168,7 @@ You can also provide a JSON configuration for new collections using the `--colle
       "http://localhost:6333",
       "--collection-name",
       "global_memories",
-      "--multi-collection-mode",
-      "--collection-config",
-      "{\"distance\": \"cosine\", \"optimizers\": {\"indexing_threshold\": 10000}}"
+      "--multi-collection-mode"
     ]
   }
 }
@@ -183,12 +180,13 @@ The configuration of the server can be also done using environment variables:
 
 - `QDRANT_URL`: URL of the Qdrant server, e.g. `http://localhost:6333`
 - `QDRANT_API_KEY`: API key for the Qdrant server
-- `COLLECTION_NAME`: Name of the collection to use
+- `COLLECTION_NAME`: Name of the collection to use, or if in mutli-collection mode, the default collection name.
 - `EMBEDDING_MODEL`: Name of the embedding model to use
 - `EMBEDDING_PROVIDER`: Embedding provider to use (currently only "fastembed" is supported)
 - `QDRANT_LOCAL_PATH`: Path to the local Qdrant database
 - `MULTI_COLLECTION_MODE`: Enable multi-collection mode for AI agents (set to any value to enable)
 - `COLLECTION_PREFIX`: Prefix for all collections in multi-collection mode
+- `PROTECT_COLLECTIONS`: Prevent deletion of memories, use `*` to block all deletion, or specify collection names to make specific collections insert only.
 
 You cannot provide `QDRANT_URL` and `QDRANT_LOCAL_PATH` at the same time.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The server supports a multi-collection mode designed for AI agents, allowing the
       "--qdrant-url",
       "http://localhost:6333",
       "--collection-name",
-      "global_memories",
+      "default_memories",
       "--multi-collection-mode",
       "--collection-prefix",
       "agent_"
@@ -152,7 +152,7 @@ The server supports a multi-collection mode designed for AI agents, allowing the
 
 In multi-collection mode:
 
-- The `collection-name` parameter specifies the global collection that's always available
+- The `collection-name` parameter specifies the default collection that's always available
 - All collections are automatically prefixed with the value of `collection-prefix` (default: "agent\_")
 - AI agents can specify which collection to store memories in or retrieve from
 - Collections are automatically created when needed
@@ -167,7 +167,7 @@ In multi-collection mode:
       "--qdrant-url",
       "http://localhost:6333",
       "--collection-name",
-      "global_memories",
+      "default_memories",
       "--multi-collection-mode"
     ]
   }

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ The configuration of the server can be also done using environment variables:
 - `QDRANT_LOCAL_PATH`: Path to the local Qdrant database
 - `MULTI_COLLECTION_MODE`: Enable multi-collection mode for AI agents (set to any value to enable)
 - `COLLECTION_PREFIX`: Prefix for all collections in multi-collection mode
-- `COLLECTION_CONFIG`: JSON configuration for new collections created in multi-collection mode
 
 You cannot provide `QDRANT_URL` and `QDRANT_LOCAL_PATH` at the same time.
 

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -18,6 +18,27 @@ class QdrantConnector:
     :param multi_collection_mode: Whether to enable multi-collection mode for AI agents.
     :param collection_prefix: Prefix for all collections in multi-collection mode.
     :param collection_config: Configuration for new collections created in multi-collection mode.
+        Expected structure:
+        {
+            "vector_params": {
+                "distance": "cosine" | "euclid" | "dot",  # Distance metric to use
+                "size": int,  # Vector size (optional, will be determined automatically if not provided)
+                # Other vector parameters supported by Qdrant
+            },
+            "shard_number": int,  # Optional number of shards in collection
+            "sharding_method": "auto" | "custom",  # Optional sharding method
+            "replication_factor": int,  # Optional replication factor
+            "write_consistency_factor": int,  # Optional write consistency factor
+            "on_disk_payload": bool,  # Optional flag to store payload on disk
+            "hnsw_config": {...},  # Optional HNSW index configuration
+            "wal_config": {...},  # Optional WAL configuration
+            "optimizers_config": {...},  # Optional Qdrant optimizers configuration
+            "init_from": {...},  # Optional initialization from another collection
+            "quantization_config": {...},  # Optional quantization configuration
+            "sparse_vectors": {...},  # Optional sparse vector configuration
+            "strict_mode_config": {...},  # Optional strict mode configuration
+            "timeout": int  # Optional timeout in seconds
+        }
     """
 
     # Regex pattern for valid collection names
@@ -81,24 +102,58 @@ class QdrantConnector:
             # Use the vector name as defined in the embedding provider
             vector_name = self._embedding_provider.get_vector_name()
             
-            # Create the collection with default or custom configuration
+            # Create default vector parameters
             vector_params = models.VectorParams(
                 size=vector_size,
                 distance=models.Distance.COSINE,
             )
             
+            # Prepare collection creation parameters with defaults
+            create_params = {
+                'collection_name': prefixed_name,
+                'vectors_config': {
+                    vector_name: vector_params
+                }
+            }
+            
             # Apply any custom configuration from collection_config
             if self._collection_config:
-                # Here you could apply custom configuration from self._collection_config
-                # For example, different distance metrics, etc.
-                pass
+                # Handle vector parameters if specified
+                if 'vector_params' in self._collection_config:
+                    vector_config = self._collection_config['vector_params']
+                    
+                    # Handle distance metric conversion from string to enum
+                    if 'distance' in vector_config:
+                        distance_str = vector_config['distance'].upper()
+                        if hasattr(models.Distance, distance_str):
+                            vector_params.distance = getattr(models.Distance, distance_str)
+                    
+                    # Apply all other vector parameters
+                    for key, value in vector_config.items():
+                        if key != 'distance' and hasattr(vector_params, key):
+                            setattr(vector_params, key, value)
                 
-            await self._client.create_collection(
-                collection_name=prefixed_name,
-                vectors_config={
-                    vector_name: vector_params
-                },
-            )
+                # Apply all other collection-level parameters
+                for param in [
+                    'optimizers_config', 
+                    'replication_factor', 
+                    'write_consistency_factor',
+                    'on_disk_payload', 
+                    'hnsw_config', 
+                    'wal_config',
+                    'quantization_config', 
+                    'init_from', 
+                    'timeout',
+                    'shard_number',
+                    'sharding_method',
+                    'sparse_vectors',
+                    'strict_mode_config'
+                ]:
+                    if param in self._collection_config:
+                        create_params[param] = self._collection_config[param]
+            
+            # Create the collection with the configured parameters
+            await self._client.create_collection(**create_params)
 
     async def list_collections(self) -> List[str]:
         """

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -108,19 +108,7 @@ class QdrantConnector:
         if collection_name == self._collection_name and not self._multi_collection_mode:
             return point_id
         return f"{collection_name}{self.MEMORY_ID_SEPARATOR}{point_id}"
-
-    def _is_collection_protected(self, collection_name: str) -> bool:
-        """
-        Check if a collection is protected from modification or deletion.
-        :param collection_name: The collection name to check
-        :return: True if the collection is protected, False otherwise
-        """
-        # If "*" is in protected_collections, all collections are protected
-        if "*" in self._protected_collections:
-            return True
-            
-        return collection_name in self._protected_collections
-        
+       
     def _is_collection_deletion_protected(self, collection_name: str) -> bool:
         """
         Check if a collection is protected from deletion operations.
@@ -128,7 +116,11 @@ class QdrantConnector:
         :param collection_name: The collection name to check
         :return: True if the collection is protected from deletion, False otherwise
         """
-        return self._is_collection_protected(collection_name)
+        # If "*" is in protected_collections, all collections are protected
+        if "*" in self._protected_collections:
+            return True
+            
+        return collection_name in self._protected_collections
         
     def _is_collection_readonly(self, collection_name: str) -> bool:
         """

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -163,26 +163,28 @@ class QdrantConnector:
         # Ensure default collection is first in the list if it exists
         if self._collection_name in collection_names:
             collection_names.remove(self._collection_name)
-            collection_names.insert(0, self._collection_name)
+
+        # always make sure the default collection is first in the list
+        collection_names.insert(0, self._collection_name)
         
         # If in multi-collection mode, filter to only show collections with the prefix
         if self._multi_collection_mode and self._collection_prefix:
+            result = [self._collection_name] # always include the default collection
+
             prefix_len = len(self._collection_prefix)
-            result = [
+            result += [
                 name[prefix_len:] 
                 for name in collection_names 
                 if name.startswith(self._collection_prefix) and name != self._collection_name
             ]
-            
-            # Add the default collection if it's not already in the list
-            # (could happen if default collection has the same prefix)
-            default_collection = self._collection_name
-            if default_collection not in result:
-                # Add default collection as the first item in the list
-                result.insert(0, default_collection)
                 
             return result
         
+        # if for some reason we're not in multi-collection mode, return the default collection
+        if not self._multi_collection_mode:
+            return [self._collection_name]
+
+        # If in multi-collection mode, and no prefix is set, return all collections
         return collection_names
 
     async def store_memory(

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -62,7 +62,16 @@ class QdrantConnector:
         :param collection_name: The collection name to prefix. If None, use the default collection name.
         :return: The prefixed collection name.
         """
-        if not self._multi_collection_mode or not collection_name:
+        # If not in multi-collection mode or collection_name is None, use the default collection name
+        if not self._multi_collection_mode:
+            return self._collection_name
+            
+        # If collection_name is None or empty, use the default collection name
+        if not collection_name:
+            return self._collection_name
+        
+        # If collection_name is the default collection name, return it as is
+        if collection_name == self._collection_name:
             return self._collection_name
         
         # Validate the collection name
@@ -95,7 +104,7 @@ class QdrantConnector:
         :param point_id: The point ID
         :return: A memory ID in the format "collection:id"
         """
-        # For the default collection, we can just return the point ID
+        # For the default collection in single-collection mode, we can just return the point ID
         if collection_name == self._collection_name and not self._multi_collection_mode:
             return point_id
         return f"{collection_name}{self.MEMORY_ID_SEPARATOR}{point_id}"
@@ -298,6 +307,7 @@ class QdrantConnector:
             if self._is_collection_protected(collection):
                 raise ValueError(f"Collection '{collection}' is protected and cannot be modified.")
                 
+            # Get the prefixed collection name - this handles the default/global collection correctly
             prefixed_name = self._get_prefixed_collection_name(collection)
             
             if prefixed_name not in collection_points:

--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -1,5 +1,6 @@
 import uuid
-from typing import Optional
+import re
+from typing import Optional, List, Dict, Any
 
 from qdrant_client import AsyncQdrantClient, models
 
@@ -11,10 +12,16 @@ class QdrantConnector:
     Encapsulates the connection to a Qdrant server and all the methods to interact with it.
     :param qdrant_url: The URL of the Qdrant server.
     :param qdrant_api_key: The API key to use for the Qdrant server.
-    :param collection_name: The name of the collection to use.
+    :param collection_name: The name of the collection to use. If multi_collection_mode is True, this is used as the global collection.
     :param embedding_provider: The embedding provider to use.
     :param qdrant_local_path: The path to the storage directory for the Qdrant client, if local mode is used.
+    :param multi_collection_mode: Whether to enable multi-collection mode for AI agents.
+    :param collection_prefix: Prefix for all collections in multi-collection mode.
+    :param collection_config: Configuration for new collections created in multi-collection mode.
     """
+
+    # Regex pattern for valid collection names
+    VALID_COLLECTION_NAME_PATTERN = re.compile(r'^[a-zA-Z0-9_-]{1,64}$')
 
     def __init__(
         self,
@@ -23,18 +30,48 @@ class QdrantConnector:
         collection_name: str,
         embedding_provider: EmbeddingProvider,
         qdrant_local_path: Optional[str] = None,
+        multi_collection_mode: bool = False,
+        collection_prefix: Optional[str] = None,
+        collection_config: Optional[Dict[str, Any]] = None,
     ):
         self._qdrant_url = qdrant_url.rstrip("/") if qdrant_url else None
         self._qdrant_api_key = qdrant_api_key
         self._collection_name = collection_name
         self._embedding_provider = embedding_provider
+        self._multi_collection_mode = multi_collection_mode
+        self._collection_prefix = collection_prefix or ""
+        self._collection_config = collection_config or {}
         self._client = AsyncQdrantClient(
             location=qdrant_url, api_key=qdrant_api_key, path=qdrant_local_path
         )
 
-    async def _ensure_collection_exists(self):
-        """Ensure that the collection exists, creating it if necessary."""
-        collection_exists = await self._client.collection_exists(self._collection_name)
+    def _get_prefixed_collection_name(self, collection_name: Optional[str] = None) -> str:
+        """
+        Get the prefixed collection name.
+        :param collection_name: The collection name to prefix. If None, use the default collection name.
+        :return: The prefixed collection name.
+        """
+        if not self._multi_collection_mode or not collection_name:
+            return self._collection_name
+        
+        # Validate the collection name
+        if not self.VALID_COLLECTION_NAME_PATTERN.match(collection_name):
+            raise ValueError(
+                f"Invalid collection name: {collection_name}. "
+                "Collection names must contain only alphanumeric characters, underscores, and hyphens, "
+                "and be between 1 and 64 characters long."
+            )
+        
+        return f"{self._collection_prefix}{collection_name}"
+
+    async def _ensure_collection_exists(self, collection_name: Optional[str] = None):
+        """
+        Ensure that the collection exists, creating it if necessary.
+        :param collection_name: The name of the collection to ensure exists. If None, use the default collection name.
+        """
+        prefixed_name = self._get_prefixed_collection_name(collection_name)
+        collection_exists = await self._client.collection_exists(prefixed_name)
+        
         if not collection_exists:
             # Create the collection with the appropriate vector size
             # We'll get the vector size by embedding a sample text
@@ -43,22 +80,54 @@ class QdrantConnector:
 
             # Use the vector name as defined in the embedding provider
             vector_name = self._embedding_provider.get_vector_name()
+            
+            # Create the collection with default or custom configuration
+            vector_params = models.VectorParams(
+                size=vector_size,
+                distance=models.Distance.COSINE,
+            )
+            
+            # Apply any custom configuration from collection_config
+            if self._collection_config:
+                # Here you could apply custom configuration from self._collection_config
+                # For example, different distance metrics, etc.
+                pass
+                
             await self._client.create_collection(
-                collection_name=self._collection_name,
+                collection_name=prefixed_name,
                 vectors_config={
-                    vector_name: models.VectorParams(
-                        size=vector_size,
-                        distance=models.Distance.COSINE,
-                    )
+                    vector_name: vector_params
                 },
             )
 
-    async def store_memory(self, information: str):
+    async def list_collections(self) -> List[str]:
+        """
+        List all collections available to the AI agent.
+        :return: A list of collection names (without the prefix).
+        """
+        collections = await self._client.get_collections()
+        collection_names = [c.name for c in collections.collections]
+        
+        # If in multi-collection mode, filter to only show collections with the prefix
+        if self._multi_collection_mode and self._collection_prefix:
+            prefix_len = len(self._collection_prefix)
+            return [
+                name[prefix_len:] 
+                for name in collection_names 
+                if name.startswith(self._collection_prefix)
+            ]
+        
+        return collection_names
+
+    async def store_memory(self, information: str, collection_name: Optional[str] = None):
         """
         Store a memory in the Qdrant collection.
         :param information: The information to store.
+        :param collection_name: The name of the collection to store the memory in. 
+                               If None, use the default collection.
         """
-        await self._ensure_collection_exists()
+        await self._ensure_collection_exists(collection_name)
+        prefixed_name = self._get_prefixed_collection_name(collection_name)
 
         # Embed the document
         embeddings = await self._embedding_provider.embed_documents([information])
@@ -66,7 +135,7 @@ class QdrantConnector:
         # Add to Qdrant
         vector_name = self._embedding_provider.get_vector_name()
         await self._client.upsert(
-            collection_name=self._collection_name,
+            collection_name=prefixed_name,
             points=[
                 models.PointStruct(
                     id=uuid.uuid4().hex,
@@ -76,13 +145,17 @@ class QdrantConnector:
             ],
         )
 
-    async def find_memories(self, query: str) -> list[str]:
+    async def find_memories(self, query: str, collection_name: Optional[str] = None) -> list[str]:
         """
         Find memories in the Qdrant collection. If there are no memories found, an empty list is returned.
         :param query: The query to use for the search.
+        :param collection_name: The name of the collection to search in. 
+                               If None, use the default collection.
         :return: A list of memories found.
         """
-        collection_exists = await self._client.collection_exists(self._collection_name)
+        prefixed_name = self._get_prefixed_collection_name(collection_name)
+        collection_exists = await self._client.collection_exists(prefixed_name)
+        
         if not collection_exists:
             return []
 
@@ -92,9 +165,38 @@ class QdrantConnector:
 
         # Search in Qdrant
         search_results = await self._client.search(
-            collection_name=self._collection_name,
+            collection_name=prefixed_name,
             query_vector=models.NamedVector(name=vector_name, vector=query_vector),
             limit=10,
         )
 
         return [result.payload["document"] for result in search_results]
+
+    async def find_memories_across_collections(self, query: str) -> Dict[str, List[str]]:
+        """
+        Find memories across all collections available to the AI agent.
+        :param query: The query to use for the search.
+        :return: A dictionary mapping collection names to lists of memories found.
+        """
+        if not self._multi_collection_mode:
+            memories = await self.find_memories(query)
+            return {self._collection_name: memories}
+        
+        collections = await self.list_collections()
+        results = {}
+        
+        # Always include the global collection
+        global_memories = await self.find_memories(query)
+        if global_memories:
+            results["global"] = global_memories
+        
+        # Search in each collection
+        for collection in collections:
+            if collection == self._collection_name:
+                continue  # Skip the global collection as we've already searched it
+                
+            memories = await self.find_memories(query, collection)
+            if memories:
+                results[collection] = memories
+                
+        return results

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -133,8 +133,7 @@ def serve(
     "--fastembed-model-name",
     envvar="FASTEMBED_MODEL_NAME",
     required=False,
-    help="FastEmbed model name",
-    default="sentence-transformers/all-MiniLM-L6-v2",
+    help="FastEmbed model name"
 )
 @click.option(
     "--embedding-provider",

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -312,11 +312,10 @@ def serve(
                     if collection == qdrant_connector._collection_name:
                         collection_extra = " (default)"
 
-                    if qdrant_connector._is_collection_deletion_protected(collection):
-                        collection_extra += " (insert-only)"
-
                     if qdrant_connector._is_collection_readonly(collection):
                         collection_extra += " (readonly)"
+                    elif qdrant_connector._is_collection_deletion_protected(collection):
+                        collection_extra += " (insert-only)"
 
                     content.append(
                         types.TextContent(type="text", text=f"- {collection}{collection_extra}")
@@ -351,12 +350,11 @@ def serve(
 
                     if collection == qdrant_connector._collection_name:
                         collection_extra = " (default)"
-
-                    if qdrant_connector._is_collection_deletion_protected(collection):
-                        collection_extra += " (insert-only)"
-
+                
                     if qdrant_connector._is_collection_readonly(collection):
                         collection_extra += " (readonly)"
+                    elif qdrant_connector._is_collection_deletion_protected(collection):
+                        collection_extra += " (insert-only)"
 
                     content.append(
                         types.TextContent(type="text", text=f"\nCollection: {collection}{collection_extra}")
@@ -486,7 +484,7 @@ def main(
     if protect_collections is not None:
         # If protect_collections is specified but empty in multi-collection mode,
         # we'll protect all collections (determined dynamically)
-        if protect_collections == "" and multi_collection_mode:
+        if protect_collections == "":
             # We'll set a flag to indicate that all collections should be protected
             # The actual collection names will be determined at runtime
             protected_collections = {"*"}  # Special marker for "all collections"
@@ -496,15 +494,15 @@ def main(
             
         # If not in multi-collection mode and protect_collections is specified,
         # assume the default collection should be protected
-        if not multi_collection_mode and protected_collections:
-            protected_collections = {collection_name}
+        if not multi_collection_mode:
+            protected_collections = {"*"}
             
     # Parse readonly collections
     readonly_collections_set = set()
     if readonly_collections is not None:
         # If readonly_collections is specified but empty in multi-collection mode,
         # we'll make all collections read-only (determined dynamically)
-        if readonly_collections == "" and multi_collection_mode:
+        if readonly_collections == "":
             # We'll set a flag to indicate that all collections should be read-only
             # The actual collection names will be determined at runtime
             readonly_collections_set = {"*"}  # Special marker for "all collections"
@@ -514,8 +512,8 @@ def main(
             
         # If not in multi-collection mode and readonly_collections is specified,
         # assume the default collection should be read-only
-        if not multi_collection_mode and readonly_collections_set:
-            readonly_collections_set = {collection_name}
+        if not multi_collection_mode:
+            readonly_collections_set = {"*"}
             
     async def _run():
         async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -296,8 +296,13 @@ def serve(
                 )
             else:
                 for collection in collections:
+                    collection_extra = ""
+                    
+                    if collection == qdrant_connector._collection_name:
+                        collection_extra = " (default)"
+
                     content.append(
-                        types.TextContent(type="text", text=f"- {collection}")
+                        types.TextContent(type="text", text=f"- {collection}{collection_extra}")
                     )
                     
             return content

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -293,6 +293,12 @@ def serve(
                     if collection == qdrant_connector._collection_name:
                         collection_extra = " (default)"
 
+                    if qdrant_connector._is_collection_deletion_protected(collection):
+                        collection_extra += " (insert-only)"
+
+                    if qdrant_connector._is_collection_readonly(collection):
+                        collection_extra += " (readonly)"
+
                     content.append(
                         types.TextContent(type="text", text=f"- {collection}{collection_extra}")
                     )
@@ -322,8 +328,19 @@ def serve(
                 all_collections_deletion_protected = "*" in qdrant_connector._protected_collections
                 
                 for collection, memories in results.items():
+                    collection_extra = ""
+
+                    if collection == qdrant_connector._collection_name:
+                        collection_extra = " (default)"
+
+                    if qdrant_connector._is_collection_deletion_protected(collection):
+                        collection_extra += " (insert-only)"
+
+                    if qdrant_connector._is_collection_readonly(collection):
+                        collection_extra += " (readonly)"
+
                     content.append(
-                        types.TextContent(type="text", text=f"\nCollection: {collection}")
+                        types.TextContent(type="text", text=f"\nCollection: {collection}{collection_extra}")
                     )
                     
                     for memory in memories:

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -41,8 +41,8 @@ def serve(
         """
         collection_name_description = (
             "Optional collection name to store the memory in. If not provided, the default collection will be used. "
-            "Collection names must contain only alphanumeric characters, underscores, and hyphens (a-z, A-Z, 0-9, _, -), "
-            "and be between 1 and 64 characters long. Examples: 'work', 'personal_notes', 'project-2023'."
+            "Collection names should be in a slug format, without special characters, and between 1 and 64 characters long. "
+            "The collection name doesn't have to exist yet, it will be created automatically."
         )
         
         # Check if all collections are protected from deletion

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -50,30 +50,6 @@ def serve(
         
         tools = [
             types.Tool(
-                name="qdrant-find-memories",
-                description=(
-                    "Look up memories in Qdrant. Use this tool when you need to: \n"
-                    " - Find memories by their content \n"
-                    " - Access memories for further analysis \n"
-                    " - Get some personal information about the user"
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "The query to search for in the memories",
-                        },
-                        **({"collection_name": {
-                            "type": "string",
-                            "description": collection_name_description,
-                        }} if qdrant_connector._multi_collection_mode else {}),
-                    },
-                    "required": ["query"],
-                },
-            ),
-            # Always add the store memory tool since collections are now insert-only, not read-only
-            types.Tool(
                 name="qdrant-store-memory",
                 description=(
                     "Keep the memory for later use, when you are asked to remember something."
@@ -97,6 +73,29 @@ def serve(
                         }} if qdrant_connector._multi_collection_mode else {}),
                     },
                     "required": ["information"],
+                },
+            ),
+            types.Tool(
+                name="qdrant-find-memories",
+                description=(
+                    "Look up memories in Qdrant. Use this tool when you need to: \n"
+                    " - Find memories by their content \n"
+                    " - Access memories for further analysis \n"
+                    " - Get some personal information about the user"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The query to search for in the memories",
+                        },
+                        **({"collection_name": {
+                            "type": "string",
+                            "description": collection_name_description,
+                        }} if qdrant_connector._multi_collection_mode else {}),
+                    },
+                    "required": ["query"],
                 },
             )
         ]

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -368,7 +368,7 @@ def serve(
     "--collection-name",
     envvar="COLLECTION_NAME",
     required=True,
-    help="Collection name (used as the default/global collection in multi-collection mode)",
+    help="Collection name (used as the default collection in multi-collection mode)",
 )
 @click.option(
     "--fastembed-model-name",

--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -64,10 +64,10 @@ def serve(
                             "type": "string",
                             "description": "The query to search for in the memories",
                         },
-                        "collection_name": {
+                        **({"collection_name": {
                             "type": "string",
                             "description": collection_name_description,
-                        },
+                        }} if qdrant_connector._multi_collection_mode else {}),
                     },
                     "required": ["query"],
                 },
@@ -88,10 +88,6 @@ def serve(
                             "information": {
                                 "type": "string",
                             },
-                            "collection_name": {
-                                "type": "string",
-                                "description": collection_name_description,
-                            },
                             "replace_memory_ids": {
                                 "type": "array",
                                 "items": {
@@ -99,6 +95,10 @@ def serve(
                                 },
                                 "description": "Optional list of memory IDs to replace with this new memory.",
                             },
+                            **({"collection_name": {
+                                "type": "string",
+                                "description": collection_name_description
+                                }} if qdrant_connector._multi_collection_mode else {}),
                         },
                         "required": ["information"],
                     },
@@ -196,7 +196,7 @@ def serve(
                 raise ValueError("Missing required argument 'information'")
             
             information = arguments["information"]
-            collection_name = arguments.get("collection_name")
+            collection_name = arguments.get("collection_name") if qdrant_connector._multi_collection_mode else None
             replace_memory_ids = arguments.get("replace_memory_ids", [])
             
             # Check if all collections are protected
@@ -226,7 +226,7 @@ def serve(
                 raise ValueError("Missing required argument 'query'")
             
             query = arguments["query"]
-            collection_name = arguments.get("collection_name")
+            collection_name = arguments.get("collection_name") if qdrant_connector._multi_collection_mode else None
             
             try:
                 memories = await qdrant_connector.find_memories(query, collection_name)
@@ -249,11 +249,11 @@ def serve(
                     
                     for memory in memories:
                         # Only show readonly tag if not all collections are protected
-                        readonly_tag = " (readonly)" if memory.get("readonly", False) and not all_collections_protected else ""
+                        readonly_tag = " readonly" if memory.get("readonly", False) and not all_collections_protected else ""
                         content.append(
                             types.TextContent(
                                 type="text", 
-                                text=f"<memory id=\"{memory['id']}\">{memory['content']}</memory>{readonly_tag}"
+                                text=f"<memory id=\"{memory['id']}\"{readonly_tag}>{memory['content']}</memory>"
                             )
                         )
                     
@@ -331,11 +331,11 @@ def serve(
                     
                     for memory in memories:
                         # Only show readonly tag if not all collections are protected
-                        readonly_tag = " (readonly)" if memory.get("readonly", False) and not all_collections_protected else ""
+                        readonly_tag = " readonly" if memory.get("readonly", False) and not all_collections_protected else ""
                         content.append(
                             types.TextContent(
                                 type="text", 
-                                text=f"<memory id=\"{memory['id']}\">{memory['content']}</memory>{readonly_tag}"
+                                text=f"<memory id=\"{memory['id']}\"{readonly_tag}>{memory['content']}</memory>"
                             )
                         )
                         

--- a/tests/test_multi_collection.py
+++ b/tests/test_multi_collection.py
@@ -32,7 +32,7 @@ async def test_multi_collection():
         connector = QdrantConnector(
             qdrant_url=None,
             qdrant_api_key=None,
-            collection_name="global",
+            collection_name="default",
             embedding_provider=provider,
             qdrant_local_path=temp_dir,
             multi_collection_mode=True,
@@ -40,8 +40,8 @@ async def test_multi_collection():
         )
         
         # Test storing memories in different collections
-        global_memory_id = await connector.store_memory("This is a global memory", None)
-        print(f"Stored global memory with ID: {global_memory_id}")
+        default_memory_id = await connector.store_memory("This is a default memory", None)
+        print(f"Stored default memory with ID: {default_memory_id}")
         
         cat_memory_id1 = await connector.store_memory("This is a memory about cats", "cats")
         print(f"Stored cat memory 1 with ID: {cat_memory_id1}")
@@ -131,7 +131,7 @@ async def test_protected_collections():
         connector = QdrantConnector(
             qdrant_url=None,
             qdrant_api_key=None,
-            collection_name="global",
+            collection_name="default",
             embedding_provider=provider,
             qdrant_local_path=temp_dir,
             multi_collection_mode=True,
@@ -140,8 +140,8 @@ async def test_protected_collections():
         )
         
         # Test storing memories in different collections
-        global_memory_id = await connector.store_memory("This is a global memory", None)
-        print(f"Stored global memory with ID: {global_memory_id}")
+        default_memory_id = await connector.store_memory("This is a default memory", None)
+        print(f"Stored default memory with ID: {default_memory_id}")
         
         # Store a memory in the unprotected "dogs" collection
         dog_memory_id = await connector.store_memory("This is a memory about dogs", "dogs")
@@ -206,7 +206,7 @@ async def test_protect_all_collections():
         connector = QdrantConnector(
             qdrant_url=None,
             qdrant_api_key=None,
-            collection_name="global",
+            collection_name="default",
             embedding_provider=provider,
             qdrant_local_path=temp_dir,
             multi_collection_mode=True,
@@ -218,8 +218,8 @@ async def test_protect_all_collections():
         connector._protected_collections.clear()
         
         # Store memories in different collections
-        global_memory_id = await connector.store_memory("This is a global memory", None)
-        print(f"Stored global memory with ID: {global_memory_id}")
+        default_memory_id = await connector.store_memory("This is a default memory", None)
+        print(f"Stored default memory with ID: {default_memory_id}")
         
         cat_memory_id = await connector.store_memory("This is a memory about cats", "cats")
         print(f"Stored cat memory with ID: {cat_memory_id}")
@@ -244,7 +244,7 @@ async def test_protect_all_collections():
             print(f"Expected error for protected collection: {e}")
             
         try:
-            await connector.store_memory("This should fail", "global")
+            await connector.store_memory("This should fail", "default")
             assert False, "Should have failed to store in protected collection"
         except ValueError as e:
             print(f"Expected error for protected collection: {e}")
@@ -285,9 +285,9 @@ async def test_protect_all_collections():
         print("All protect all collections tests passed!")
 
 
-async def test_delete_global_memories():
-    """Test deleting memories from the global collection in multi-collection mode."""
-    print("\nTesting deletion of memories from global collection in multi-collection mode...")
+async def test_delete_default_memories():
+    """Test deleting memories from the default collection in multi-collection mode."""
+    print("\nTesting deletion of memories from default collection in multi-collection mode...")
     
     # Create a temporary directory for Qdrant local storage
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -301,67 +301,67 @@ async def test_delete_global_memories():
         connector = QdrantConnector(
             qdrant_url=None,
             qdrant_api_key=None,
-            collection_name="global",
+            collection_name="default",
             embedding_provider=provider,
             qdrant_local_path=temp_dir,
             multi_collection_mode=True,
             collection_prefix="test_",
         )
         
-        # Store memories in the global collection
-        global_memory_id1 = await connector.store_memory("This is the first global memory")
-        print(f"Stored global memory 1 with ID: {global_memory_id1}")
+        # Store memories in the default collection
+        default_memory_id1 = await connector.store_memory("This is the first default memory")
+        print(f"Stored default memory 1 with ID: {default_memory_id1}")
         
-        global_memory_id2 = await connector.store_memory("This is the second global memory")
-        print(f"Stored global memory 2 with ID: {global_memory_id2}")
+        default_memory_id2 = await connector.store_memory("This is the second default memory")
+        print(f"Stored default memory 2 with ID: {default_memory_id2}")
         
         # Store a memory in a different collection for comparison
         other_memory_id = await connector.store_memory("This is a memory in another collection", "other")
         print(f"Stored memory in 'other' collection with ID: {other_memory_id}")
         
         # Verify memories exist before deletion
-        global_memories_before = await connector.find_memories("global memory")
-        print(f"Global memories before deletion: {json.dumps(global_memories_before, indent=2)}")
-        assert len(global_memories_before) == 2, f"Expected 2 global memories, found {len(global_memories_before)}"
+        default_memories_before = await connector.find_memories("default memory")
+        print(f"Default memories before deletion: {json.dumps(default_memories_before, indent=2)}")
+        assert len(default_memories_before) == 2, f"Expected 2 default memories, found {len(default_memories_before)}"
         
         other_memories_before = await connector.find_memories("other", "other")
         print(f"Other memories before deletion: {json.dumps(other_memories_before, indent=2)}")
         assert len(other_memories_before) == 1, f"Expected 1 memory in 'other' collection, found {len(other_memories_before)}"
         
-        # Delete one memory from the global collection
-        deleted_count = await connector.delete_memories([global_memory_id1])
-        print(f"Deleted {deleted_count} memory from global collection")
+        # Delete one memory from the default collection
+        deleted_count = await connector.delete_memories([default_memory_id1])
+        print(f"Deleted {deleted_count} memory from default collection")
         assert deleted_count == 1, f"Expected to delete 1 memory, but deleted {deleted_count}"
         
         # Verify the memory was deleted
-        global_memories_after = await connector.find_memories("global memory")
-        print(f"Global memories after deletion: {json.dumps(global_memories_after, indent=2)}")
-        assert len(global_memories_after) == 1, f"Expected 1 global memory after deletion, found {len(global_memories_after)}"
+        default_memories_after = await connector.find_memories("default memory")
+        print(f"Default memories after deletion: {json.dumps(default_memories_after, indent=2)}")
+        assert len(default_memories_after) == 1, f"Expected 1 default memory after deletion, found {len(default_memories_after)}"
         
         # Verify the other collection is unaffected
         other_memories_after = await connector.find_memories("other", "other")
         print(f"Other memories after deletion: {json.dumps(other_memories_after, indent=2)}")
         assert len(other_memories_after) == 1, f"Expected 1 memory in 'other' collection, found {len(other_memories_after)}"
         
-        # Delete the remaining global memory and the memory in the other collection
-        deleted_count = await connector.delete_memories([global_memory_id2, other_memory_id])
+        # Delete the remaining default memory and the memory in the other collection
+        deleted_count = await connector.delete_memories([default_memory_id2, other_memory_id])
         print(f"Deleted {deleted_count} memories")
         assert deleted_count == 2, f"Expected to delete 2 memories, but deleted {deleted_count}"
         
         # Verify all memories were deleted
-        global_memories_final = await connector.find_memories("global memory")
-        print(f"Global memories after final deletion: {json.dumps(global_memories_final, indent=2)}")
-        assert len(global_memories_final) == 0, f"Expected 0 global memories, found {len(global_memories_final)}"
+        default_memories_final = await connector.find_memories("default memory")
+        print(f"Default memories after final deletion: {json.dumps(default_memories_final, indent=2)}")
+        assert len(default_memories_final) == 0, f"Expected 0 default memories, found {len(default_memories_final)}"
         
         other_memories_final = await connector.find_memories("other", "other")
         print(f"Other memories after final deletion: {json.dumps(other_memories_final, indent=2)}")
         assert len(other_memories_final) == 0, f"Expected 0 memories in 'other' collection, found {len(other_memories_final)}"
         
-        print("All global memory deletion tests passed!")
+        print("All default memory deletion tests passed!")
 
 
 if __name__ == "__main__":
     asyncio.run(test_multi_collection())
     asyncio.run(test_protected_collections())
     asyncio.run(test_protect_all_collections())
-    asyncio.run(test_delete_global_memories()) 
+    asyncio.run(test_delete_default_memories()) 

--- a/tests/test_multi_collection.py
+++ b/tests/test_multi_collection.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Test script for multi-collection functionality in mcp-server-qdrant.
+This script tests the basic operations of storing and retrieving memories
+across multiple collections.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+import uuid
+from typing import Dict, List, Optional
+
+from mcp_server_qdrant.embeddings.factory import create_embedding_provider
+from mcp_server_qdrant.qdrant import QdrantConnector
+
+
+async def test_multi_collection():
+    """Test multi-collection functionality."""
+    print("Testing multi-collection functionality...")
+    
+    # Create a temporary directory for Qdrant local storage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create embedding provider
+        provider = create_embedding_provider(
+            provider_type="fastembed",
+            model_name="sentence-transformers/all-MiniLM-L6-v2"
+        )
+        
+        # Create QdrantConnector with multi-collection mode enabled
+        connector = QdrantConnector(
+            qdrant_url=None,
+            qdrant_api_key=None,
+            collection_name="global",
+            embedding_provider=provider,
+            qdrant_local_path=temp_dir,
+            multi_collection_mode=True,
+            collection_prefix="test_",
+        )
+        
+        # Test storing memories in different collections
+        await connector.store_memory("This is a global memory", None)
+        await connector.store_memory("This is a memory about cats", "cats")
+        await connector.store_memory("This is another memory about cats", "cats")
+        await connector.store_memory("This is a memory about dogs", "dogs")
+        
+        # Test listing collections
+        collections = await connector.list_collections()
+        print(f"Available collections: {collections}")
+        assert "cats" in collections, "Collection 'cats' not found"
+        assert "dogs" in collections, "Collection 'dogs' not found"
+        
+        # Test finding memories in specific collections
+        cat_memories = await connector.find_memories("cats", "cats")
+        print(f"Cat memories: {cat_memories}")
+        assert len(cat_memories) > 0, "No cat memories found"
+        
+        dog_memories = await connector.find_memories("dogs", "dogs")
+        print(f"Dog memories: {dog_memories}")
+        assert len(dog_memories) > 0, "No dog memories found"
+        
+        # Test finding memories across collections
+        all_memories = await connector.find_memories_across_collections("pets")
+        print(f"All memories: {json.dumps(all_memories, indent=2)}")
+        
+        # Test invalid collection name
+        try:
+            await connector.store_memory("This should fail", "invalid name with spaces")
+            assert False, "Should have failed with invalid collection name"
+        except ValueError as e:
+            print(f"Expected error for invalid collection name: {e}")
+        
+        print("All tests passed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_multi_collection()) 

--- a/tests/test_multi_collection.py
+++ b/tests/test_multi_collection.py
@@ -253,12 +253,12 @@ async def test_protect_all_collections():
         cat_memories = await connector.find_memories("cats", "cats")
         print(f"Cat memories: {json.dumps(cat_memories, indent=2)}")
         assert len(cat_memories) > 0, "No cat memories found"
-        assert cat_memories[0].get("readonly", False), "Memory should be marked as readonly"
+        assert cat_memories[0].get("readonly", False), "Memory should be marked as readonly in the connector"
         
         dog_memories = await connector.find_memories("dogs", "dogs")
         print(f"Dog memories: {json.dumps(dog_memories, indent=2)}")
         assert len(dog_memories) > 0, "No dog memories found"
-        assert dog_memories[0].get("readonly", False), "Memory should be marked as readonly"
+        assert dog_memories[0].get("readonly", False), "Memory should be marked as readonly in the connector"
         
         # Test deleting from any collection (should fail)
         try:
@@ -280,7 +280,7 @@ async def test_protect_all_collections():
         # Verify readonly status in results for all collections
         for collection, memories in all_memories.items():
             for memory in memories:
-                assert memory.get("readonly", False), f"{collection} memory should be marked as readonly"
+                assert memory.get("readonly", False), f"{collection} memory should be marked as readonly in the connector"
         
         print("All protect all collections tests passed!")
 

--- a/tests/test_multi_collection.py
+++ b/tests/test_multi_collection.py
@@ -285,7 +285,83 @@ async def test_protect_all_collections():
         print("All protect all collections tests passed!")
 
 
+async def test_delete_global_memories():
+    """Test deleting memories from the global collection in multi-collection mode."""
+    print("\nTesting deletion of memories from global collection in multi-collection mode...")
+    
+    # Create a temporary directory for Qdrant local storage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create embedding provider
+        provider = create_embedding_provider(
+            provider_type="fastembed",
+            model_name="sentence-transformers/all-MiniLM-L6-v2"
+        )
+        
+        # Create QdrantConnector with multi-collection mode enabled
+        connector = QdrantConnector(
+            qdrant_url=None,
+            qdrant_api_key=None,
+            collection_name="global",
+            embedding_provider=provider,
+            qdrant_local_path=temp_dir,
+            multi_collection_mode=True,
+            collection_prefix="test_",
+        )
+        
+        # Store memories in the global collection
+        global_memory_id1 = await connector.store_memory("This is the first global memory")
+        print(f"Stored global memory 1 with ID: {global_memory_id1}")
+        
+        global_memory_id2 = await connector.store_memory("This is the second global memory")
+        print(f"Stored global memory 2 with ID: {global_memory_id2}")
+        
+        # Store a memory in a different collection for comparison
+        other_memory_id = await connector.store_memory("This is a memory in another collection", "other")
+        print(f"Stored memory in 'other' collection with ID: {other_memory_id}")
+        
+        # Verify memories exist before deletion
+        global_memories_before = await connector.find_memories("global memory")
+        print(f"Global memories before deletion: {json.dumps(global_memories_before, indent=2)}")
+        assert len(global_memories_before) == 2, f"Expected 2 global memories, found {len(global_memories_before)}"
+        
+        other_memories_before = await connector.find_memories("other", "other")
+        print(f"Other memories before deletion: {json.dumps(other_memories_before, indent=2)}")
+        assert len(other_memories_before) == 1, f"Expected 1 memory in 'other' collection, found {len(other_memories_before)}"
+        
+        # Delete one memory from the global collection
+        deleted_count = await connector.delete_memories([global_memory_id1])
+        print(f"Deleted {deleted_count} memory from global collection")
+        assert deleted_count == 1, f"Expected to delete 1 memory, but deleted {deleted_count}"
+        
+        # Verify the memory was deleted
+        global_memories_after = await connector.find_memories("global memory")
+        print(f"Global memories after deletion: {json.dumps(global_memories_after, indent=2)}")
+        assert len(global_memories_after) == 1, f"Expected 1 global memory after deletion, found {len(global_memories_after)}"
+        
+        # Verify the other collection is unaffected
+        other_memories_after = await connector.find_memories("other", "other")
+        print(f"Other memories after deletion: {json.dumps(other_memories_after, indent=2)}")
+        assert len(other_memories_after) == 1, f"Expected 1 memory in 'other' collection, found {len(other_memories_after)}"
+        
+        # Delete the remaining global memory and the memory in the other collection
+        deleted_count = await connector.delete_memories([global_memory_id2, other_memory_id])
+        print(f"Deleted {deleted_count} memories")
+        assert deleted_count == 2, f"Expected to delete 2 memories, but deleted {deleted_count}"
+        
+        # Verify all memories were deleted
+        global_memories_final = await connector.find_memories("global memory")
+        print(f"Global memories after final deletion: {json.dumps(global_memories_final, indent=2)}")
+        assert len(global_memories_final) == 0, f"Expected 0 global memories, found {len(global_memories_final)}"
+        
+        other_memories_final = await connector.find_memories("other", "other")
+        print(f"Other memories after final deletion: {json.dumps(other_memories_final, indent=2)}")
+        assert len(other_memories_final) == 0, f"Expected 0 memories in 'other' collection, found {len(other_memories_final)}"
+        
+        print("All global memory deletion tests passed!")
+
+
 if __name__ == "__main__":
     asyncio.run(test_multi_collection())
     asyncio.run(test_protected_collections())
-    asyncio.run(test_protect_all_collections()) 
+    asyncio.run(test_protect_all_collections())
+    asyncio.run(test_delete_global_memories()) 

--- a/tests/test_multi_collection.py
+++ b/tests/test_multi_collection.py
@@ -10,7 +10,7 @@ import json
 import os
 import tempfile
 import uuid
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from mcp_server_qdrant.embeddings.factory import create_embedding_provider
 from mcp_server_qdrant.qdrant import QdrantConnector
@@ -40,10 +40,17 @@ async def test_multi_collection():
         )
         
         # Test storing memories in different collections
-        await connector.store_memory("This is a global memory", None)
-        await connector.store_memory("This is a memory about cats", "cats")
-        await connector.store_memory("This is another memory about cats", "cats")
-        await connector.store_memory("This is a memory about dogs", "dogs")
+        global_memory_id = await connector.store_memory("This is a global memory", None)
+        print(f"Stored global memory with ID: {global_memory_id}")
+        
+        cat_memory_id1 = await connector.store_memory("This is a memory about cats", "cats")
+        print(f"Stored cat memory 1 with ID: {cat_memory_id1}")
+        
+        cat_memory_id2 = await connector.store_memory("This is another memory about cats", "cats")
+        print(f"Stored cat memory 2 with ID: {cat_memory_id2}")
+        
+        dog_memory_id = await connector.store_memory("This is a memory about dogs", "dogs")
+        print(f"Stored dog memory with ID: {dog_memory_id}")
         
         # Test listing collections
         collections = await connector.list_collections()
@@ -53,16 +60,50 @@ async def test_multi_collection():
         
         # Test finding memories in specific collections
         cat_memories = await connector.find_memories("cats", "cats")
-        print(f"Cat memories: {cat_memories}")
+        print(f"Cat memories: {json.dumps(cat_memories, indent=2)}")
         assert len(cat_memories) > 0, "No cat memories found"
+        assert "id" in cat_memories[0], "Memory ID not found in result"
+        assert "content" in cat_memories[0], "Memory content not found in result"
         
         dog_memories = await connector.find_memories("dogs", "dogs")
-        print(f"Dog memories: {dog_memories}")
+        print(f"Dog memories: {json.dumps(dog_memories, indent=2)}")
         assert len(dog_memories) > 0, "No dog memories found"
+        assert "id" in dog_memories[0], "Memory ID not found in result"
+        assert "content" in dog_memories[0], "Memory content not found in result"
         
         # Test finding memories across collections
         all_memories = await connector.find_memories_across_collections("pets")
         print(f"All memories: {json.dumps(all_memories, indent=2)}")
+        
+        # Test replacing memories
+        updated_cat_memory_id = await connector.store_memory(
+            "This is an updated memory about cats",
+            "cats",
+            replace_memory_ids=[cat_memory_id1]
+        )
+        print(f"Updated cat memory with ID: {updated_cat_memory_id}")
+        
+        # Verify the memory was replaced
+        cat_memories_after_update = await connector.find_memories("cats", "cats")
+        print(f"Cat memories after update: {json.dumps(cat_memories_after_update, indent=2)}")
+        
+        # Check if the old memory ID is no longer present
+        cat_memory_ids = [memory["id"] for memory in cat_memories_after_update]
+        assert cat_memory_id1 not in cat_memory_ids, "Old memory ID should not be present after replacement"
+        
+        # Test deleting memories
+        deleted_count = await connector.delete_memories([cat_memory_id2, dog_memory_id])
+        print(f"Deleted {deleted_count} memories")
+        assert deleted_count == 2, f"Expected to delete 2 memories, but deleted {deleted_count}"
+        
+        # Verify memories were deleted
+        cat_memories_after_delete = await connector.find_memories("cats", "cats")
+        print(f"Cat memories after delete: {json.dumps(cat_memories_after_delete, indent=2)}")
+        assert len(cat_memories_after_delete) < len(cat_memories_after_update), "Cat memory not deleted"
+        
+        dog_memories_after_delete = await connector.find_memories("dogs", "dogs")
+        print(f"Dog memories after delete: {json.dumps(dog_memories_after_delete, indent=2)}")
+        assert len(dog_memories_after_delete) == 0, "Dog memory not deleted"
         
         # Test invalid collection name
         try:
@@ -74,5 +115,177 @@ async def test_multi_collection():
         print("All tests passed!")
 
 
+async def test_protected_collections():
+    """Test protected collections functionality."""
+    print("\nTesting protected collections functionality...")
+    
+    # Create a temporary directory for Qdrant local storage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create embedding provider
+        provider = create_embedding_provider(
+            provider_type="fastembed",
+            model_name="sentence-transformers/all-MiniLM-L6-v2"
+        )
+        
+        # Create QdrantConnector with multi-collection mode enabled and protected collections
+        connector = QdrantConnector(
+            qdrant_url=None,
+            qdrant_api_key=None,
+            collection_name="global",
+            embedding_provider=provider,
+            qdrant_local_path=temp_dir,
+            multi_collection_mode=True,
+            collection_prefix="test_",
+            protected_collections={"cats"}  # Protect the "cats" collection
+        )
+        
+        # Test storing memories in different collections
+        global_memory_id = await connector.store_memory("This is a global memory", None)
+        print(f"Stored global memory with ID: {global_memory_id}")
+        
+        # Store a memory in the unprotected "dogs" collection
+        dog_memory_id = await connector.store_memory("This is a memory about dogs", "dogs")
+        print(f"Stored dog memory with ID: {dog_memory_id}")
+        
+        # Test storing in a protected collection (should fail)
+        try:
+            await connector.store_memory("This should fail", "cats")
+            assert False, "Should have failed to store in protected collection"
+        except ValueError as e:
+            print(f"Expected error for protected collection: {e}")
+        
+        # Create a memory in the protected collection by temporarily removing protection
+        connector._protected_collections.remove("cats")
+        cat_memory_id = await connector.store_memory("This is a memory about cats", "cats")
+        print(f"Stored cat memory with ID: {cat_memory_id}")
+        connector._protected_collections.add("cats")
+        
+        # Test finding memories in protected collection (should work)
+        cat_memories = await connector.find_memories("cats", "cats")
+        print(f"Cat memories: {json.dumps(cat_memories, indent=2)}")
+        assert len(cat_memories) > 0, "No cat memories found"
+        assert cat_memories[0].get("readonly", False), "Memory should be marked as readonly"
+        
+        # Test deleting from protected collection (should fail)
+        try:
+            await connector.delete_memories([cat_memory_id])
+            assert False, "Should have failed to delete from protected collection"
+        except ValueError as e:
+            print(f"Expected error for deleting from protected collection: {e}")
+        
+        # Test deleting from unprotected collection (should work)
+        deleted_count = await connector.delete_memories([dog_memory_id])
+        print(f"Deleted {deleted_count} memories")
+        assert deleted_count == 1, f"Expected to delete 1 memory, but deleted {deleted_count}"
+        
+        # Test finding memories across collections
+        all_memories = await connector.find_memories_across_collections("pets")
+        print(f"All memories: {json.dumps(all_memories, indent=2)}")
+        
+        # Verify readonly status in results
+        if "cats" in all_memories:
+            for memory in all_memories["cats"]:
+                assert memory.get("readonly", False), "Cat memory should be marked as readonly"
+        
+        print("All protected collections tests passed!")
+
+
+async def test_protect_all_collections():
+    """Test protecting all collections functionality."""
+    print("\nTesting protect all collections functionality...")
+    
+    # Create a temporary directory for Qdrant local storage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create embedding provider
+        provider = create_embedding_provider(
+            provider_type="fastembed",
+            model_name="sentence-transformers/all-MiniLM-L6-v2"
+        )
+        
+        # Create QdrantConnector with multi-collection mode enabled and all collections protected
+        connector = QdrantConnector(
+            qdrant_url=None,
+            qdrant_api_key=None,
+            collection_name="global",
+            embedding_provider=provider,
+            qdrant_local_path=temp_dir,
+            multi_collection_mode=True,
+            collection_prefix="test_",
+            protected_collections={"*"}  # Protect all collections
+        )
+        
+        # Create some collections first by temporarily removing protection
+        connector._protected_collections.clear()
+        
+        # Store memories in different collections
+        global_memory_id = await connector.store_memory("This is a global memory", None)
+        print(f"Stored global memory with ID: {global_memory_id}")
+        
+        cat_memory_id = await connector.store_memory("This is a memory about cats", "cats")
+        print(f"Stored cat memory with ID: {cat_memory_id}")
+        
+        dog_memory_id = await connector.store_memory("This is a memory about dogs", "dogs")
+        print(f"Stored dog memory with ID: {dog_memory_id}")
+        
+        # Re-enable protection for all collections
+        connector._protected_collections = {"*"}
+        
+        # Test storing in any collection (should fail)
+        try:
+            await connector.store_memory("This should fail", "cats")
+            assert False, "Should have failed to store in protected collection"
+        except ValueError as e:
+            print(f"Expected error for protected collection: {e}")
+            
+        try:
+            await connector.store_memory("This should fail", "dogs")
+            assert False, "Should have failed to store in protected collection"
+        except ValueError as e:
+            print(f"Expected error for protected collection: {e}")
+            
+        try:
+            await connector.store_memory("This should fail", "global")
+            assert False, "Should have failed to store in protected collection"
+        except ValueError as e:
+            print(f"Expected error for protected collection: {e}")
+        
+        # Test finding memories in protected collections (should work)
+        cat_memories = await connector.find_memories("cats", "cats")
+        print(f"Cat memories: {json.dumps(cat_memories, indent=2)}")
+        assert len(cat_memories) > 0, "No cat memories found"
+        assert cat_memories[0].get("readonly", False), "Memory should be marked as readonly"
+        
+        dog_memories = await connector.find_memories("dogs", "dogs")
+        print(f"Dog memories: {json.dumps(dog_memories, indent=2)}")
+        assert len(dog_memories) > 0, "No dog memories found"
+        assert dog_memories[0].get("readonly", False), "Memory should be marked as readonly"
+        
+        # Test deleting from any collection (should fail)
+        try:
+            await connector.delete_memories([cat_memory_id])
+            assert False, "Should have failed to delete from protected collection"
+        except ValueError as e:
+            print(f"Expected error for deleting from protected collection: {e}")
+            
+        try:
+            await connector.delete_memories([dog_memory_id])
+            assert False, "Should have failed to delete from protected collection"
+        except ValueError as e:
+            print(f"Expected error for deleting from protected collection: {e}")
+        
+        # Test finding memories across collections
+        all_memories = await connector.find_memories_across_collections("pets")
+        print(f"All memories: {json.dumps(all_memories, indent=2)}")
+        
+        # Verify readonly status in results for all collections
+        for collection, memories in all_memories.items():
+            for memory in memories:
+                assert memory.get("readonly", False), f"{collection} memory should be marked as readonly"
+        
+        print("All protect all collections tests passed!")
+
+
 if __name__ == "__main__":
-    asyncio.run(test_multi_collection()) 
+    asyncio.run(test_multi_collection())
+    asyncio.run(test_protected_collections())
+    asyncio.run(test_protect_all_collections()) 


### PR DESCRIPTION
# Overview
I added a few quality of life features that I find helpful for my needs in Cursor. Feel free to take or leave these features, since it's a bit of AI slop.

This feature is backwards compatible with previous versions of the code, and is only a bolt on for anyone who wants new stuff.

# Bugfixes:
It fixes that pesky warning every time the MCP is run, about `--fastembed-model-name` being deprecated. Now it will only show if its actually being specified.

# Features:
## Multi-collection mode
To start using multi-collection mode, first specify `--mutli-collection-mode`, this will allow the MCP to utilize multiple collections. By default, it will only interact with collections prefixed with `agent_`, but this can be changed or removed by defining `--collection-prefix`.

## Updating and Deleting memories
Updating and deleting memories are now possible. Since its possible that your memory size will get too big, or too much data that may be returned for one query.

There also is an option to disallow the removal of memories by specifying `--protect-collections`, making all collections insert only. You can also protect specific collections, if in multi-collection mode by specifying the collection names (excluding the prefix).

## Readonly Collections
Since I already basically implemented readonly collection behaviors, I just went the last mile and added it. Specify `--readonly-collections` to make collections operate in readonly mode. If in multi-collection mode, no value will place all collections in readonly mode. Otherwise you can specify which collections to place in readonly mode via comma separation.
