### PR TITLE
Update the README to reflect the new default for FASTMCP_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ important ones are listed below:
 |---------------------------------------|-----------------------------------------------------------|---------------|
 | `FASTMCP_DEBUG`                       | Enable debug mode                                         | `false`       |
 | `FASTMCP_LOG_LEVEL`                   | Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | `INFO`        |
-| `FASTMCP_HOST`                        | Host address to bind the server to                        | `0.0.0.0`     |
+| `FASTMCP_HOST`                        | Host address to bind the server to                        | `127.0.0.1`   |
 | `FASTMCP_PORT`                        | Port to run the server on                                 | `8000`        |
 | `FASTMCP_WARN_ON_DUPLICATE_RESOURCES` | Show warnings for duplicate resources                     | `true`        |
 | `FASTMCP_WARN_ON_DUPLICATE_TOOLS`     | Show warnings for duplicate tools                         | `true`        |
@@ -121,11 +121,16 @@ docker build -t mcp-server-qdrant .
 
 # Run the container
 docker run -p 8000:8000 \
+  -e FASTMCP_HOST="0.0.0.0" \
   -e QDRANT_URL="http://your-qdrant-server:6333" \
   -e QDRANT_API_KEY="your-api-key" \
   -e COLLECTION_NAME="your-collection" \
   mcp-server-qdrant
 ```
+
+> [!TIP]
+> Please note that we set `FASTMCP_HOST="0.0.0.0"` to make the server listen on all network interfaces. This is
+> necessary when running the server in a Docker container.
 
 ### Installing via Smithery
 


### PR DESCRIPTION
FastMCP has changed the default value for `FASTMCP_HOST` from `0.0.0.0` to `127.0.0.1`. That was making the Dockerfile unusable for SSE.

Context: https://github.com/jlowin/fastmcp/blame/159324ea468652ec3a86837b0f9f85ce89a795df/src/fastmcp/settings.py#L192