### PR TITLE
Add `_env_parse_none_str` configuration to QdrantSettings

### DIFF
--- a/src/mcp_server_qdrant/server.py
+++ b/src/mcp_server_qdrant/server.py
@@ -7,6 +7,6 @@ from mcp_server_qdrant.settings import (
 
 mcp = QdrantMCPServer(
     tool_settings=ToolSettings(),
-    qdrant_settings=QdrantSettings(),
+    qdrant_settings=QdrantSettings(_env_parse_none_str="None"),
     embedding_provider_settings=EmbeddingProviderSettings(),
 )


### PR DESCRIPTION
This pull request introduces a minor update to the `QdrantMCPServer` initialization in `src/mcp_server_qdrant/server.py`. The change involves modifying the `QdrantSettings` instantiation to include a new parameter, `_env_parse_none_str`, with the value `"None"`.

- [`src/mcp_server_qdrant/server.py`](diffhunk://#diff-8eb1a369b4f20110b537c8ff6261e9f13f61f52213f94600714f609171b119c8L10-R10): Updated the `QdrantSettings` instantiation to include `_env_parse_none_str="None"` for enhanced environment parsing behavior.