### PR TITLE
Support configuring FastEmbed threads

### DIFF
--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -12,6 +12,6 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
     if settings.provider_type == EmbeddingProviderType.FASTEMBED:
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
-        return FastEmbedProvider(settings.model_name)
+        return FastEmbedProvider(settings.model_name, threads=settings.threads)
     else:
         raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/fastembed.py
+++ b/src/mcp_server_qdrant/embeddings/fastembed.py
@@ -10,11 +10,13 @@ class FastEmbedProvider(EmbeddingProvider):
     """
     FastEmbed implementation of the embedding provider.
     :param model_name: The name of the FastEmbed model to use.
+
+    All other named parameters get passed to `fastembed.TextEmbedding`.
     """
 
-    def __init__(self, model_name: str):
+    def __init__(self, model_name: str, **kwargs):
         self.model_name = model_name
-        self.embedding_model = TextEmbedding(model_name)
+        self.embedding_model = TextEmbedding(model_name, **kwargs)
 
     async def embed_documents(self, documents: list[str]) -> list[list[float]]:
         """Embed a list of documents into vectors."""

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings
@@ -45,6 +45,10 @@ class EmbeddingProviderSettings(BaseSettings):
     model_name: str = Field(
         default="sentence-transformers/all-MiniLM-L6-v2",
         validation_alias="EMBEDDING_MODEL",
+    )
+    threads: Optional[int] = Field(
+        validation_alias="EMBEDDING_THREADS",
+        default=None,
     )
 
 


### PR DESCRIPTION
Makes it possible to configure fastembed's thread config via `EMBEDING_THREADS` environment variable. If the variable isn't set, defaults to current behavior.

Fixes error:
```
[E:onnxruntime:Default, env.cc:234 ThreadMain] pthread_setaffinity_np failed for thread: 1656, index: 2, mask: {3, 7, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.
```

Necessary when running in an environment where the setaffinity syscall is not available, like in GKE's Autopilot environment.