### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/mcp_server_qdrant/mcp_server.py
+++ b/src/mcp_server_qdrant/mcp_server.py
@@ -3,6 +3,7 @@ import logging
 from typing import Annotated, Any, Optional
 
 from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 from qdrant_client import models
 
@@ -188,6 +189,10 @@ class QdrantMCPServer(FastMCP):
             find_foo,
             name="qdrant-find",
             description=self.tool_settings.tool_find_description,
+            annotations=ToolAnnotations(
+                title="Find in Qdrant",
+                readOnlyHint=True,
+            ),
         )
 
         if not self.qdrant_settings.read_only:
@@ -196,4 +201,8 @@ class QdrantMCPServer(FastMCP):
                 store_foo,
                 name="qdrant-store",
                 description=self.tool_settings.tool_store_description,
+                annotations=ToolAnnotations(
+                    title="Store in Qdrant",
+                    destructiveHint=True,
+                ),
             )


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`) to all tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to `qdrant-find` (read-only search tool)
- Added `destructiveHint: true` to `qdrant-store` (data modification tool)
- Added `title` annotations for human-readable display

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations

## Testing

- [x] All 24 tests pass
- [x] Ruff linter passes
- [x] **Live verification:** Created server instance and confirmed `tools/list` returns annotations:
  ```
  Tool Name            Title                ReadOnly   Destructive
  ------------------------------------------------------------
  qdrant-find          Find in Qdrant       True       N/A       
  qdrant-store         Store in Qdrant      N/A        True      
  ```

## Before/After

**Before:**
```python
self.tool(
    find_foo,
    name="qdrant-find",
    description=self.tool_settings.tool_find_description,
)
```

**After:**
```python
self.tool(
    find_foo,
    name="qdrant-find",
    description=self.tool_settings.tool_find_description,
    annotations=ToolAnnotations(
        title="Find in Qdrant",
        readOnlyHint=True,
    ),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)