### PR TITLE
Add Ollama embedding provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [
     "fastembed>=0.6.0",
+    "httpx>=0.27.0",
     "qdrant-client>=1.12.0",
     "pydantic>=2.10.6,<2.12.0",
     "fastmcp==2.7.0",

--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -6,6 +6,7 @@ from mcp_server_qdrant.settings import EmbeddingProviderSettings
 def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingProvider:
     """
     Create an embedding provider based on the specified type.
+
     :param settings: The settings for the embedding provider.
     :return: An instance of the specified embedding provider.
     """
@@ -13,5 +14,14 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
         return FastEmbedProvider(settings.model_name)
+
+    elif settings.provider_type == EmbeddingProviderType.OLLAMA:
+        from mcp_server_qdrant.embeddings.ollama import OllamaEmbeddingProvider
+
+        return OllamaEmbeddingProvider(
+            model_name=settings.model_name,
+            ollama_url=settings.ollama_url,
+        )
+
     else:
         raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/ollama.py
+++ b/src/mcp_server_qdrant/embeddings/ollama.py
@@ -1,0 +1,60 @@
+import httpx
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    """
+    Ollama implementation of the embedding provider.
+
+    :param model_name: The name of the Ollama embedding model (e.g., 'embeddinggemma', 'nomic-embed-text').
+    :param ollama_url: The base URL of the Ollama API (default: http://localhost:11434).
+    """
+
+    def __init__(self, model_name: str, ollama_url: str = "http://localhost:11434"):
+        self.model_name = model_name
+        self.ollama_url = ollama_url.rstrip("/")
+        self._vector_size: int | None = None
+
+    async def _get_embedding(self, text: str) -> list[float]:
+        """Get embedding for a single text."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.ollama_url}/api/embeddings",
+                json={"model": self.model_name, "prompt": text},
+                timeout=60.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["embedding"]
+
+    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
+        """Embed a list of documents into vectors."""
+        embeddings = []
+        for doc in documents:
+            embedding = await self._get_embedding(doc)
+            embeddings.append(embedding)
+        return embeddings
+
+    async def embed_query(self, query: str) -> list[float]:
+        """Embed a query into a vector."""
+        return await self._get_embedding(query)
+
+    def get_vector_name(self) -> str:
+        """Return the name of the vector for the Qdrant collection."""
+        model_name = self.model_name.replace("/", "-").replace(":", "-").lower()
+        return f"ollama-{model_name}"
+
+    def get_vector_size(self) -> int:
+        """Get the size of the vector for the Qdrant collection."""
+        if self._vector_size is None:
+            # Get vector size by doing a test embedding synchronously
+            response = httpx.post(
+                f"{self.ollama_url}/api/embeddings",
+                json={"model": self.model_name, "prompt": "test"},
+                timeout=60.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            self._vector_size = len(data["embedding"])
+        return self._vector_size

--- a/src/mcp_server_qdrant/embeddings/types.py
+++ b/src/mcp_server_qdrant/embeddings/types.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class EmbeddingProviderType(Enum):
     FASTEMBED = "fastembed"
+    OLLAMA = "ollama"

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -46,6 +46,10 @@ class EmbeddingProviderSettings(BaseSettings):
         default="sentence-transformers/all-MiniLM-L6-v2",
         validation_alias="EMBEDDING_MODEL",
     )
+    ollama_url: str = Field(
+        default="http://localhost:11434",
+        validation_alias="OLLAMA_URL",
+    )
 
 
 class FilterableField(BaseModel):


### PR DESCRIPTION
## Ollama Embedding Support

Adds support for Ollama as an embedding provider, enabling the use of local embedding models like `embeddinggemma`.

### Changes:
- New file: `src/mcp_server_qdrant/embeddings/ollama.py`
- Updated: `embeddings/types.py` - Added OLLAMA enum
- Updated: `embeddings/factory.py` - Added Ollama provider creation
- Updated: `settings.py` - Added `ollama_url` setting
- Updated: `pyproject.toml` - Added `httpx` dependency

### New Environment Variables:
| Variable | Description | Default |
|----------|-------------|---------|
| EMBEDDING_PROVIDER | `fastembed` or `ollama` | `fastembed` |
| EMBEDDING_MODEL | Model name | `sentence-transformers/all-MiniLM-L6-v2` |
| OLLAMA_URL | Ollama API URL | `http://localhost:11434` |

### Tested with:
- Ollama model: `embeddinggemma:300m`
- Qdrant: v1.x
- Msty Studio via Sidecar