### PR TITLE
feat: Add Google Gemini embedding provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,16 @@ dependencies = [
     "qdrant-client>=1.12.0",
     "pydantic>=2.10.6,<2.12.0",
     "fastmcp==2.7.0",
+    "google-genai==1.65.0",
+]
+
+[tool.hatch.envs.hatch-test]
+extra-dependencies = [
+    "pytest-asyncio",
+    "pytest-mock",
+    "pytest-xdist",
+    "pytest-rerunfailures",
+    "numpy",
 ]
 
 [build-system]

--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -13,5 +13,12 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
         return FastEmbedProvider(settings.model_name)
+    elif settings.provider_type == EmbeddingProviderType.GEMINI:
+        from mcp_server_qdrant.embeddings.gemini import GeminiEmbeddingProvider
+
+        return GeminiEmbeddingProvider(
+            model_name=settings.model_name,
+            api_key=settings.gemini_api_key,
+        )
     else:
         raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/gemini.py
+++ b/src/mcp_server_qdrant/embeddings/gemini.py
@@ -1,0 +1,103 @@
+"""Google Gemini embedding provider for mcp-server-qdrant."""
+
+from typing import Optional
+
+from google import genai
+from google.genai import types
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+
+
+class GeminiEmbeddingProvider(EmbeddingProvider):
+    """Embedding provider using Google's Gemini API."""
+
+    def __init__(self, model_name: str, api_key: str):
+        """
+        Initialize the Gemini embedding provider.
+
+        :param model_name: The name of the Gemini model to use.
+        :param api_key: The Google API key for authentication.
+        """
+        self._model_name = model_name.replace("models/", "")
+        self._client = genai.Client(api_key=api_key)
+        self._dimension: Optional[int] = None
+
+    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
+        """
+        Embed a list of documents into vectors.
+
+        :param documents: A list of text documents to embed.
+        :return: A list of embedding vectors.
+        """
+        response = await self._client.aio.models.embed_content(
+            model=self._model_name,
+            contents=documents,
+            config=types.EmbedContentConfig(
+                task_type="RETRIEVAL_DOCUMENT",
+            ),
+        )
+
+        embeddings = [e.values for e in response.embeddings]
+
+        # Cache dimension on first call
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+
+        return embeddings
+
+    async def embed_query(self, query: str) -> list[float]:
+        """
+        Embed a query into a vector.
+
+        :param query: The query text to embed.
+        :return: The embedding vector for the query.
+        """
+        response = await self._client.aio.models.embed_content(
+            model=self._model_name,
+            contents=[query],
+            config=types.EmbedContentConfig(
+                task_type="RETRIEVAL_QUERY",
+            ),
+        )
+
+        embeddings = [e.values for e in response.embeddings]
+
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+
+        return embeddings[0]
+
+    def get_vector_name(self) -> str:
+        """
+        Get the name of the vector for the Qdrant collection.
+
+        :return: The vector name in '{slug}' format.
+        """
+        slug = self._model_name.split("/")[-1]
+        return f"{slug}"
+
+    def get_vector_size(self) -> int:
+        """
+        Get the size of the vector for the Qdrant collection.
+
+        :return: The dimension of the embeddings.
+        """
+        if self._dimension is not None:
+            return self._dimension
+
+        # Sync probe call
+        response = self._client.models.embed_content(
+            model=self._model_name,
+            contents=["test"],
+            config=types.EmbedContentConfig(
+                task_type="RETRIEVAL_QUERY",
+            ),
+        )
+
+        if response.embeddings:
+            self._dimension = len(response.embeddings[0].values)
+
+        if self._dimension is None:
+            raise ValueError("Could not determine embedding dimension from Gemini API")
+
+        return self._dimension

--- a/src/mcp_server_qdrant/embeddings/types.py
+++ b/src/mcp_server_qdrant/embeddings/types.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class EmbeddingProviderType(Enum):
     FASTEMBED = "fastembed"
+    GEMINI = "gemini"

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -46,6 +46,10 @@ class EmbeddingProviderSettings(BaseSettings):
         default="sentence-transformers/all-MiniLM-L6-v2",
         validation_alias="EMBEDDING_MODEL",
     )
+    gemini_api_key: str = Field(
+        default="",
+        validation_alias="GEMINI_API_KEY",
+    )
 
 
 class FilterableField(BaseModel):

--- a/tests/test_gemini_integration.py
+++ b/tests/test_gemini_integration.py
@@ -1,0 +1,159 @@
+import os
+import pytest
+import numpy as np
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_server_qdrant.embeddings.gemini import GeminiEmbeddingProvider
+
+@pytest.mark.asyncio
+class TestGeminiEmbeddingProviderUnit:
+    """Unit tests for GeminiEmbeddingProvider with mocked API."""
+
+    @pytest.fixture
+    def mock_genai_client(self):
+        """Mock genai.Client for testing without API calls."""
+        with patch('mcp_server_qdrant.embeddings.gemini.genai.Client') as mock_client_class:
+            mock_instance = MagicMock()
+            mock_client_class.return_value = mock_instance
+            
+            # Mock async embed_content
+            mock_embedding1 = MagicMock()
+            mock_embedding1.values = [0.1] * 768
+            mock_embedding2 = MagicMock()
+            mock_embedding2.values = [0.2] * 768
+            
+            mock_response = MagicMock()
+            mock_response.embeddings = [mock_embedding1, mock_embedding2]
+            mock_instance.aio.models.embed_content = AsyncMock(return_value=mock_response)
+            
+            # Mock sync embed_content
+            mock_instance.models.embed_content = MagicMock(return_value=mock_response)
+            
+            yield mock_instance
+
+    @pytest.fixture
+    def gemini_provider(self, mock_genai_client):
+        """Create provider instance with mocked client."""
+        return GeminiEmbeddingProvider(model_name="text-embedding-004", api_key="fake-key")
+
+    async def test_initialization(self, gemini_provider):
+        """Test provider setup, model name normalization."""
+        assert gemini_provider._model_name == "text-embedding-004"
+        assert gemini_provider.get_vector_name() == "gemini-text-embedding-004"
+
+    async def test_model_name_normalization(self, mock_genai_client):
+        """Test stripping of models/ prefix."""
+        provider = GeminiEmbeddingProvider(model_name="models/text-embedding-004", api_key="fake-key")
+        assert provider._model_name == "text-embedding-004"
+
+    async def test_embed_documents(self, gemini_provider, mock_genai_client):
+        """Test batch embedding with mocked response."""
+        documents = ["Hello world", "Test document"]
+        embeddings = await gemini_provider.embed_documents(documents)
+        
+        assert len(embeddings) == len(documents)
+        assert all(len(emb) == 768 for emb in embeddings)
+        
+        mock_genai_client.aio.models.embed_content.assert_called_once()
+        args, kwargs = mock_genai_client.aio.models.embed_content.call_args
+        assert kwargs['model'] == "text-embedding-004"
+        assert kwargs['contents'] == documents
+
+    async def test_embed_query(self, gemini_provider, mock_genai_client):
+        """Test single query embedding."""
+        query = "What is MCP?"
+        embedding = await gemini_provider.embed_query(query)
+        
+        assert len(embedding) == 768
+        mock_genai_client.aio.models.embed_content.assert_called_once()
+        args, kwargs = mock_genai_client.aio.models.embed_content.call_args
+        assert kwargs['contents'] == [query]
+
+    async def test_get_vector_name(self, gemini_provider):
+        """Test naming convention gemini-{slug}."""
+        assert gemini_provider.get_vector_name() == "gemini-text-embedding-004"
+
+    async def test_get_vector_size_cached(self, gemini_provider):
+        """Test dimension when cached."""
+        gemini_provider._dimension = 1536
+        assert gemini_provider.get_vector_size() == 1536
+
+    async def test_get_vector_size_probe(self, gemini_provider, mock_genai_client):
+        """Test dimension probe when not cached."""
+        assert gemini_provider._dimension is None
+        size = gemini_provider.get_vector_size()
+        
+        assert size == 768
+        assert gemini_provider._dimension == 768
+        mock_genai_client.models.embed_content.assert_called_once()
+
+    async def test_dimension_caching(self, gemini_provider, mock_genai_client):
+        """Verify dimension is cached after first call."""
+        assert gemini_provider._dimension is None
+        
+        # First call (async)
+        await gemini_provider.embed_query("test")
+        assert gemini_provider._dimension == 768
+        
+        # Second call (sync size check) - should use cache
+        mock_genai_client.models.embed_content.reset_mock()
+        assert gemini_provider.get_vector_size() == 768
+        mock_genai_client.models.embed_content.assert_not_called()
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not os.getenv("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set")
+class TestGeminiEmbeddingProviderIntegration:
+    """Integration tests for GeminiEmbeddingProvider with real API."""
+
+    @pytest.fixture
+    def api_key(self):
+        """Get API key from environment."""
+        key = os.getenv("GOOGLE_API_KEY")
+        if not key:
+            pytest.skip("GOOGLE_API_KEY not set")
+        return key
+
+    @pytest.fixture
+    def real_gemini_provider(self, api_key):
+        """Real provider for integration tests."""
+        return GeminiEmbeddingProvider(model_name="text-embedding-004", api_key=api_key)
+
+    async def test_real_embed_documents(self, real_gemini_provider):
+        """Test with real API."""
+        documents = ["This is a test document.", "This is another test document."]
+        embeddings = await real_gemini_provider.embed_documents(documents)
+        
+        assert len(embeddings) == len(documents)
+        assert all(len(emb) > 0 for emb in embeddings)
+        
+        embedding1 = np.array(embeddings[0])
+        embedding2 = np.array(embeddings[1])
+        assert not np.array_equal(embedding1, embedding2)
+
+    async def test_real_embed_query(self, real_gemini_provider):
+        """Test query embedding."""
+        query = "This is a test query."
+        embedding = await real_gemini_provider.embed_query(query)
+        
+        assert len(embedding) > 0
+        
+        # Consistency check
+        embedding2 = await real_gemini_provider.embed_query(query)
+        np.testing.assert_array_almost_equal(np.array(embedding), np.array(embedding2))
+
+    async def test_real_consistency(self, real_gemini_provider):
+        """Verify same input produces same output."""
+        text = "Consistency test"
+        res1 = await real_gemini_provider.embed_query(text)
+        res2 = await real_gemini_provider.embed_query(text)
+        np.testing.assert_array_almost_equal(np.array(res1), np.array(res2))
+
+    async def test_real_vector_metadata(self, real_gemini_provider):
+        """Test vector name and size."""
+        assert real_gemini_provider.get_vector_name().startswith("gemini-")
+        size = real_gemini_provider.get_vector_size()
+        assert size > 0
+        
+        # Verify it matches embedding length
+        embedding = await real_gemini_provider.embed_query("test")
+        assert len(embedding) == size

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,18 @@ from mcp_server_qdrant.settings import (
 
 
 class TestQdrantSettings:
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch):
+        """Ensure no QDRANT environment variables interfere with tests."""
+        monkeypatch.delenv("QDRANT_URL", raising=False)
+        monkeypatch.delenv("QDRANT_API_KEY", raising=False)
+        monkeypatch.delenv("COLLECTION_NAME", raising=False)
+        monkeypatch.delenv("QDRANT_LOCAL_PATH", raising=False)
+        monkeypatch.delenv("QDRANT_SEARCH_LIMIT", raising=False)
+        monkeypatch.delenv("QDRANT_READ_ONLY", raising=False)
+        monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
+
     def test_default_values(self):
         """Test that required fields raise errors when not provided."""
 


### PR DESCRIPTION
Adds support for Google's Gemini embedding models through a new GeminiEmbeddingProvider.

Motivation:

Currently I have a shared qdrant which is an index of my web site, it has existing embedding.

Changes:
- New embedding provider in src/mcp_server_qdrant/embeddings/gemini.py
- Uses Google's new GA google-genai SDK (one additional dependency)
- Supports all Gemini embedding models (e.g., models/text-embedding-004)
- Native async implementation using client.aio for better performance
- Auto-detects embedding dimensions with caching
- Task-specific embeddings (RETRIEVAL_DOCUMENT vs RETRIEVAL_QUERY)
- Comprehensive test suite with unit and integration tests

Configuration:
- EMBEDDING_PROVIDER=gemini
- EMBEDDING_MODEL=models/text-embedding-004 (or other Gemini models)
- GEMINI_API_KEY=your_api_key

Example:
```bash
export EMBEDDING_PROVIDER=gemini
export EMBEDDING_MODEL=models/text-embedding-004
export GEMINI_API_KEY=your_google_api_key
```