### PR TITLE
fix: Prevent Resource Exhaustion and Metadata Exfiltration in FastMCP tools

### DIFF
--- a/src/mcp_server_qdrant/mcp_server.py
+++ b/src/mcp_server_qdrant/mcp_server.py
@@ -92,13 +92,23 @@ class QdrantMCPServer(FastMCP):
 
         async def store(
             ctx: Context,
-            information: Annotated[str, Field(description="Text to store")],
+            information: Annotated[
+                str, 
+                Field(
+                    description="Text to store", 
+                    max_length=50000 # PATCH: Prevent Local OOM Crashes
+                )
+            ],
             collection_name: Annotated[
                 str, Field(description="The collection to store the information in")
             ],
-            # The `metadata` parameter is defined as non-optional, but it can be None.
-            # If we set it to be optional, some of the MCP clients, like Cursor, cannot
-            # handle the optional parameter correctly.
+            # PATCH: Mandatory Agentic Guardrail
+            confirm_store: Annotated[
+                bool,
+                Field(
+                    description="Mandatory security flag. You MUST prompt the user for confirmation before setting this to true. If false, the operation will be rejected."
+                )
+            ] = False,
             metadata: Annotated[
                 Metadata | None,
                 Field(
@@ -115,6 +125,10 @@ class QdrantMCPServer(FastMCP):
                                     the default collection is used.
             :return: A message indicating that the information was stored.
             """
+            # PATCH: Enforce the confirmation
+            if not confirm_store:
+                return "Error: Storage operation cancelled. 'confirm_store' flag must be explicitly set to true after receiving human confirmation."
+            
             await ctx.debug(f"Storing information {information} in Qdrant")
 
             entry = Entry(content=information, metadata=metadata)
@@ -126,11 +140,22 @@ class QdrantMCPServer(FastMCP):
 
         async def find(
             ctx: Context,
-            query: Annotated[str, Field(description="What to search for")],
+            query: Annotated[
+                str, 
+                Field(
+                    description="What to search for",
+                    max_length=10000 # PATCH: Prevent Local OOM Crashes
+                )
+            ],
             collection_name: Annotated[
                 str, Field(description="The collection to search in")
             ],
             query_filter: ArbitraryFilter | None = None,
+            #Metadata Firewall
+            selected_metadata_keys: Annotated[
+                list[str] | None,
+                Field(description="A list of specific metadata keys to return. Use this to prevent pulling unnecessary or sensitive data into context.")
+            ] = None,
         ) -> list[str] | None:
             """
             Find memories in Qdrant.
@@ -161,7 +186,14 @@ class QdrantMCPServer(FastMCP):
                 f"Results for the query '{query}'",
             ]
             for entry in entries:
+                #Apply the metadata firewall before formatting
+                if entry.metadata and selected_metadata_keys is not None:
+                    entry.metadata = {
+                        k: v for k, v in entry.metadata.items() 
+                        if k in selected_metadata_keys
+                    }
                 content.append(self.format_entry(entry))
+                
             return content
 
         find_foo = find

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+
+from mcp_server_qdrant.mcp_server import QdrantMCPServer
+from mcp_server_qdrant.qdrant import Entry
+
+@pytest.fixture
+def mock_server():
+    """Instantiates a mock server and captures tools using a pre-emptive monkeypatch."""
+    # 1. Setup mock settings to satisfy the constructor
+    mock_settings = MagicMock()
+    mock_settings.search_limit = 10
+    mock_settings.location = ":memory:"
+    mock_settings.url = mock_settings.host = mock_settings.path = mock_settings.local_path = None
+    
+    #Force the server into write-mode so the store tool registers
+    mock_settings.read_only = False
+
+    mock_tool_settings = MagicMock()
+    mock_tool_settings.tool_find_description = "Find memories."
+    mock_tool_settings.tool_store_description = "Store memories."
+    
+    captured_tools = {}
+
+    # 2. Define the interception wrapper
+    # We use *args, **kwargs to be completely blind to how FastMCP passes data
+    original_tool_method = QdrantMCPServer.tool
+
+    def capture_tool_wrapper(self, *args, **kwargs):
+        # Capture the function (usually first arg) and the name (keyword or second arg)
+        fn = args[0] if args else kwargs.get('fn')
+        name = kwargs.get('name')
+        if not name and len(args) > 1:
+            name = args[1]
+        
+        if fn:
+            # If no name is found, fallback to the function's own name
+            key = name or getattr(fn, "__name__", "unknown")
+            captured_tools[key] = fn
+            
+        return original_tool_method(self, *args, **kwargs)
+
+    # 3. Apply the patch to the CLASS, then instantiate
+    with patch.object(QdrantMCPServer, 'tool', capture_tool_wrapper):
+        server = QdrantMCPServer(
+            qdrant_settings=mock_settings,
+            tool_settings=mock_tool_settings,
+            embedding_provider=MagicMock()
+        )
+    
+    # 4. Mock the database connector AFTER init is finished
+    server.qdrant_connector = MagicMock()
+    server.qdrant_connector.search = AsyncMock()
+    server.qdrant_connector.store = AsyncMock()
+    
+    # Normalize tool names (remove 'qdrant-' prefix if present)
+    normalized = {}
+    for name, fn in captured_tools.items():
+        clean_name = name.replace('qdrant-', '')
+        normalized[clean_name] = fn
+    captured_tools.update(normalized)
+    
+    server.captured_tools = captured_tools
+    return server
+
+@pytest.mark.asyncio
+async def test_store_requires_confirmation(mock_server):
+    """Verify that autonomous agents cannot write data without the confirm_store flag."""
+    store_fn = mock_server.captured_tools.get('store')
+    assert store_fn is not None, f"Store tool not found. Registered: {list(mock_server.captured_tools.keys())}"
+    
+    mock_ctx = MagicMock()
+    mock_ctx.debug = AsyncMock()
+    
+    # Execute WITHOUT confirmation flag
+    # These handlers are closures that already have 'self' bound, so we don't pass it.
+    result = await store_fn(
+        ctx=mock_ctx,
+        information="Malicious hallucinated data",
+        collection_name="test_collection",
+        confirm_store=False
+    )
+    
+    assert "Error: Storage operation cancelled" in result
+    mock_server.qdrant_connector.store.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_find_metadata_firewall(mock_server):
+    """Verify that the search tool strips unrequested PII from the metadata payload."""
+    find_fn = mock_server.captured_tools.get('find')
+    assert find_fn is not None, f"Find tool not found. Registered: {list(mock_server.captured_tools.keys())}"
+    
+    mock_ctx = MagicMock()
+    mock_ctx.debug = AsyncMock()
+    
+    # Mock database returning a record with sensitive PII
+    mock_server.qdrant_connector.search.return_value = [
+        Entry(
+            content="Internal document",
+            metadata={"public": "ok", "ssn": "secret-PII", "internal_note": "top secret"}
+        )
+    ]
+    
+    # Execute search with a specific whitelist
+    results = await find_fn(
+        ctx=mock_ctx,
+        query="test",
+        collection_name="test_collection",
+        selected_metadata_keys=["public"]
+    )
+    
+    assert results is not None, "Expected search results, but got None" # Add this line
+    output_string = "".join(results)
+    assert "public" in output_string
+    assert "ssn" not in output_string
+    assert "internal_note" not in output_string


### PR DESCRIPTION
## Summary
This PR hardens the qdrant-find and qdrant-store tools against common vulnerabilities encountered in autonomous LLM workflows, specifically local Resource Exhaustion (DoS), vector space pollution, and sensitive metadata exfiltration.

## Key Changes:

**Pydantic max_length Constraints (DoS Prevention)**: Added max_length bounds to the information (50,000) and query (10,000) strings. Previously, unbounded inputs allowed LLMs to pass massive hallucinated strings, which could cause local Out-Of-Memory (OOM) crashes when processed by the local fastembed Python instance.

**Mandatory confirm_store Guardrail (Data Pollution Prevention):**
Added a mandatory confirm_store: bool flag to the store tool. This forces an autonomous agent to halt and explicitly request human confirmation before injecting new data into the vector database, preventing silent data pollution.

**selected_metadata_keys Firewall (PII Exfiltration Prevention):**
Added an optional metadata filter to the find tool. Previously, the tool serialized the entire Qdrant metadata JSON payload back into the context window. This patch allows developers to restrict which metadata keys are exposed to the LLM, preventing accidental leakage of internal IDs or PII.

**Dedicated Security Test Suite:**
Added tests/test_mcp_security.py using unittest.mock.patch to verify these FastMCP tool guardrails without requiring a live database connection.

## Testing:

[x] Ran uv run pytest

[x] Verified existing integration tests pass.

[x] Verified the 2 new security assertions pass successfully.