### PR TITLE
feat: add OpenRouter embedding provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ The configuration of the server is done using environment variables:
 | `QDRANT_API_KEY`         | API key for the Qdrant server                                       | None                                                              |
 | `COLLECTION_NAME`        | Name of the default collection to use.                              | None                                                              |
 | `QDRANT_LOCAL_PATH`      | Path to the local Qdrant database (alternative to `QDRANT_URL`)     | None                                                              |
-| `EMBEDDING_PROVIDER`     | Embedding provider to use (currently only "fastembed" is supported) | `fastembed`                                                       |
+| `EMBEDDING_PROVIDER`     | Embedding provider to use (`"fastembed"` or `"openrouter"`)         | `fastembed`                                                       |
 | `EMBEDDING_MODEL`        | Name of the embedding model to use                                  | `sentence-transformers/all-MiniLM-L6-v2`                          |
+| `OPENROUTER_API_KEY`     | API key for OpenRouter (required when using `"openrouter"` provider) | None                                                             |
 | `TOOL_STORE_DESCRIPTION` | Custom description for the store tool                               | See default in [`settings.py`](src/mcp_server_qdrant/settings.py) |
 | `TOOL_FIND_DESCRIPTION`  | Custom description for the find tool                                | See default in [`settings.py`](src/mcp_server_qdrant/settings.py) |
 
@@ -179,7 +180,8 @@ For local Qdrant mode:
 This MCP server will automatically create a collection with the specified name if it doesn't exist.
 
 By default, the server will use the `sentence-transformers/all-MiniLM-L6-v2` embedding model to encode memories.
-For the time being, only [FastEmbed](https://qdrant.github.io/fastembed/) models are supported.
+[FastEmbed](https://qdrant.github.io/fastembed/) and [OpenRouter](https://openrouter.ai/) are supported as embedding
+providers.
 
 ## Support for other tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "qdrant-client>=1.12.0",
     "pydantic>=2.10.6,<2.12.0",
     "fastmcp==2.7.0",
+    "httpx>=0.24.0",
 ]
 
 [build-system]

--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -13,5 +13,14 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
         return FastEmbedProvider(settings.model_name)
+    elif settings.provider_type == EmbeddingProviderType.OPENROUTER:
+        from mcp_server_qdrant.embeddings.openrouter import OpenRouterEmbeddingProvider, OpenRouterEmbeddingSettings
+
+        # Create OpenRouter settings from the general settings
+        openrouter_settings = OpenRouterEmbeddingSettings(
+            api_key=settings.openrouter_api_key,
+            model_name=settings.model_name,
+        )
+        return OpenRouterEmbeddingProvider(openrouter_settings)
     else:
         raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/openrouter.py
+++ b/src/mcp_server_qdrant/embeddings/openrouter.py
@@ -1,0 +1,112 @@
+import logging
+import os
+from typing import List, Optional
+
+import httpx
+from pydantic import BaseModel
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenRouterEmbeddingSettings(BaseModel):
+    """Settings for OpenRouter embedding provider."""
+
+    api_key: Optional[str] = None
+    model_name: str = "text-embedding-3-small"
+    base_url: str = "https://openrouter.ai/api/v1"
+
+
+class OpenRouterEmbeddingProvider(EmbeddingProvider):
+    """
+    OpenRouter implementation of the embedding provider.
+    Uses OpenRouter's API to generate embeddings for text.
+    """
+
+    def __init__(self, settings: OpenRouterEmbeddingSettings):
+        self.settings = settings
+        self.api_key = settings.api_key or os.getenv("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "OpenRouter API key is required. Set OPENROUTER_API_KEY environment variable or provide in settings."
+            )
+        self.model_name = settings.model_name
+
+    async def embed_documents(self, documents: List[str]) -> List[List[float]]:
+        """Embed a list of documents into vectors."""
+        if not documents:
+            return []
+        return await self._make_embedding_request(documents)
+
+    async def embed_query(self, query: str) -> List[float]:
+        """Embed a query into a vector."""
+        if not query:
+            return []
+        embeddings = await self._make_embedding_request([query])
+        return embeddings[0]
+
+    async def _make_embedding_request(self, texts: List[str]) -> List[List[float]]:
+        """Make the async HTTP request to OpenRouter API."""
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model_name,
+            "input": texts,
+            "encoding_format": "float",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    f"{self.settings.base_url}/embeddings",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+                return [item["embedding"] for item in data["data"]]
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"OpenRouter API error: {e.response.status_code} - {e.response.text}"
+            )
+        except Exception as e:
+            raise RuntimeError(f"Error making OpenRouter embedding request: {str(e)}")
+
+    def get_vector_name(self) -> str:
+        """Return the name of the vector for the Qdrant collection."""
+        model_name = self.model_name.replace("/", "-").replace(":", "-")
+        return f"openrouter-{model_name}"
+
+    def get_vector_size(self) -> int:
+        """Get the size of the vector for the Qdrant collection."""
+        env_size = os.getenv("OPENROUTER_EMBEDDING_SIZE")
+        if env_size:
+            return int(env_size)
+
+        known_sizes = {
+            "text-embedding-3-small": 1536,
+            "text-embedding-3-large": 3072,
+            "text-embedding-ada-002": 1536,
+            "mistral-embed": 1024,
+            "nomic-embed-text": 768,
+            "nomic-ai/nomic-embed-text-v1.5": 768,
+            "qwen/qwen3-embedding": 2048,
+            "qwen/qwen3-embedding-8b": 4096,
+        }
+        if self.model_name in known_sizes:
+            return known_sizes[self.model_name]
+
+        if "large" in self.model_name:
+            fallback = 3072
+        else:
+            fallback = 1536
+        logger.warning(
+            "Unknown OpenRouter model '%s': vector size defaulting to %d. "
+            "Set OPENROUTER_EMBEDDING_SIZE to override.",
+            self.model_name,
+            fallback,
+        )
+        return fallback

--- a/src/mcp_server_qdrant/embeddings/openrouter.py
+++ b/src/mcp_server_qdrant/embeddings/openrouter.py
@@ -76,7 +76,16 @@ class OpenRouterEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError(f"Error making OpenRouter embedding request: {str(e)}")
 
     def get_vector_name(self) -> str:
-        """Return the name of the vector for the Qdrant collection."""
+        """Return the name of the vector for the Qdrant collection.
+
+        Honors ``QDRANT_VECTOR_NAME`` so the server can target collections
+        whose vectors use a different field name than the model-derived
+        default (e.g. ones populated by an external indexer such as cocoindex,
+        which writes under the field ``embedding``).
+        """
+        override = os.getenv("QDRANT_VECTOR_NAME")
+        if override:
+            return override
         model_name = self.model_name.replace("/", "-").replace(":", "-")
         return f"openrouter-{model_name}"
 

--- a/src/mcp_server_qdrant/embeddings/types.py
+++ b/src/mcp_server_qdrant/embeddings/types.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class EmbeddingProviderType(Enum):
     FASTEMBED = "fastembed"
+    OPENROUTER = "openrouter"

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -1,26 +1,31 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings
 
 from mcp_server_qdrant.embeddings.types import EmbeddingProviderType
 
-DEFAULT_TOOL_STORE_DESCRIPTION = (
-    "Keep the memory for later use, when you are asked to remember something."
-)
-DEFAULT_TOOL_FIND_DESCRIPTION = (
-    "Look up memories in Qdrant. Use this tool when you need to: \n"
-    " - Find memories by their content \n"
-    " - Access memories for further analysis \n"
-    " - Get some personal information about the user"
-)
+
 
 METADATA_PATH = "metadata"
+
+DEFAULT_TOOL_STORE_DESCRIPTION = (
+    "Store information in the Qdrant vector database. "
+    "The information will be stored in a collection with the name provided in the collection_name parameter. "
+    "The information will be embedded using the configured embedding model and stored in the collection. "
+    "The information can be retrieved later using the find tool."
+)
+DEFAULT_TOOL_FIND_DESCRIPTION = (
+    "Find information in the Qdrant vector database. "
+    "The information will be retrieved from a collection with the name provided in the collection_name parameter. "
+    "The query will be embedded using the configured embedding model and used to search for similar information in the collection. "
+    "The results will be returned as a list of strings."
+)
 
 
 class ToolSettings(BaseSettings):
     """
-    Configuration for all the tools.
+    Configuration for the tools.
     """
 
     tool_store_description: str = Field(
@@ -46,6 +51,18 @@ class EmbeddingProviderSettings(BaseSettings):
         default="sentence-transformers/all-MiniLM-L6-v2",
         validation_alias="EMBEDDING_MODEL",
     )
+    openrouter_api_key: Optional[str] = Field(
+        default=None,
+        validation_alias="OPENROUTER_API_KEY",
+    )
+
+    @model_validator(mode="after")
+    def check_openrouter_api_key(self) -> "EmbeddingProviderSettings":
+        if self.provider_type == EmbeddingProviderType.OPENROUTER and not self.openrouter_api_key:
+            raise ValueError(
+                "OPENROUTER_API_KEY is required when using the OpenRouter embedding provider."
+            )
+        return self
 
 
 class FilterableField(BaseModel):
@@ -84,9 +101,7 @@ class QdrantSettings(BaseSettings):
     local_path: str | None = Field(default=None, validation_alias="QDRANT_LOCAL_PATH")
     search_limit: int = Field(default=10, validation_alias="QDRANT_SEARCH_LIMIT")
     read_only: bool = Field(default=False, validation_alias="QDRANT_READ_ONLY")
-
     filterable_fields: list[FilterableField] | None = Field(default=None)
-
     allow_arbitrary_filter: bool = Field(
         default=False, validation_alias="QDRANT_ALLOW_ARBITRARY_FILTER"
     )

--- a/tests/test_openrouter_integration.py
+++ b/tests/test_openrouter_integration.py
@@ -1,0 +1,172 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server_qdrant.embeddings.openrouter import OpenRouterEmbeddingProvider, OpenRouterEmbeddingSettings
+
+
+@pytest.fixture
+def mock_embedding_settings():
+    """Create a mock embedding settings object."""
+    return OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+
+@pytest.fixture
+def mock_embedding_provider(mock_embedding_settings):
+    """Create a mock embedding provider."""
+    return OpenRouterEmbeddingProvider(mock_embedding_settings)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_initialization():
+    """Test that OpenRouter provider initializes correctly."""
+    settings = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+    provider = OpenRouterEmbeddingProvider(settings)
+
+    assert provider.settings.api_key == "test_api_key"
+    assert provider.settings.model_name == "text-embedding-3-small"
+    assert provider.model_name == "text-embedding-3-small"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_vector_name():
+    """Test that OpenRouter provider generates correct vector names."""
+    settings = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+    provider = OpenRouterEmbeddingProvider(settings)
+
+    vector_name = provider.get_vector_name()
+    assert vector_name == "openrouter-text-embedding-3-small"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_vector_size():
+    """Test that OpenRouter provider returns correct vector sizes."""
+    # Test small model
+    settings_small = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+    provider_small = OpenRouterEmbeddingProvider(settings_small)
+    assert provider_small.get_vector_size() == 1536
+
+    # Test large model
+    settings_large = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-large"
+    )
+
+    provider_large = OpenRouterEmbeddingProvider(settings_large)
+    assert provider_large.get_vector_size() == 3072
+
+    # Test default case (unknown model without "large" in name)
+    settings_default = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="some-other-model"
+    )
+
+    provider_default = OpenRouterEmbeddingProvider(settings_default)
+    assert provider_default.get_vector_size() == 1536
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_vector_size_env_override():
+    """Test that OPENROUTER_EMBEDDING_SIZE env var overrides the default size."""
+    settings = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="some-custom-model"
+    )
+    provider = OpenRouterEmbeddingProvider(settings)
+
+    with patch.dict(os.environ, {"OPENROUTER_EMBEDDING_SIZE": "2048"}):
+        assert provider.get_vector_size() == 2048
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_openrouter_provider_embed_documents(mock_client_class):
+    """Test that OpenRouter provider can embed documents."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"embedding": [0.1, 0.2, 0.3]},
+            {"embedding": [0.4, 0.5, 0.6]}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    settings = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+    provider = OpenRouterEmbeddingProvider(settings)
+
+    documents = ["Hello world", "Test document"]
+    result = await provider.embed_documents(documents)
+
+    assert len(result) == 2
+    assert result[0] == [0.1, 0.2, 0.3]
+    assert result[1] == [0.4, 0.5, 0.6]
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_openrouter_provider_embed_query(mock_client_class):
+    """Test that OpenRouter provider can embed a query."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"embedding": [0.1, 0.2, 0.3]}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    settings = OpenRouterEmbeddingSettings(
+        api_key="test_api_key",
+        model_name="text-embedding-3-small"
+    )
+
+    provider = OpenRouterEmbeddingProvider(settings)
+
+    query = "Test query"
+    result = await provider.embed_query(query)
+
+    assert len(result) == 3
+    assert result == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_no_api_key():
+    """Test that OpenRouter provider raises error when no API key is provided."""
+    settings = OpenRouterEmbeddingSettings(
+        api_key=None,
+        model_name="text-embedding-3-small"
+    )
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("OPENROUTER_API_KEY", None)
+        with pytest.raises(ValueError, match="OpenRouter API key is required"):
+            OpenRouterEmbeddingProvider(settings)

--- a/uv.lock
+++ b/uv.lock
@@ -963,6 +963,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastembed" },
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "qdrant-client" },
 ]
@@ -983,6 +984,7 @@ dev = [
 requires-dist = [
     { name = "fastembed", specifier = ">=0.6.0" },
     { name = "fastmcp", specifier = "==2.7.0" },
+    { name = "httpx", specifier = ">=0.24.0" },
     { name = "pydantic", specifier = ">=2.10.6,<2.12.0" },
     { name = "qdrant-client", specifier = ">=1.12.0" },
 ]


### PR DESCRIPTION
Motivation                                                

  When working with large codebases, local embedding models (via FastEmbed) can be slow or      
  impractical due to memory and CPU constraints. This PR adds support for OpenRouter as an
  embedding provider, allowing users to use cloud-hosted embedding models without running       
  anything locally.                                         

Changes

  - New OpenRouterEmbeddingProvider using httpx.AsyncClient for async HTTP requests             
  - EMBEDDING_PROVIDER=openrouter and OPENROUTER_API_KEY env vars to configure the provider
  - Optional OPENROUTER_EMBEDDING_SIZE env var to override vector size for unknown models       
  - Early validation: startup fails immediately if OPENROUTER_API_KEY is missing                
  - Tests covering initialization, vector naming, size resolution, embedding calls, and missing 
  key error                                                                                     
  - README updated with new env vars documentation                                              
                                                                                                
  Usage                                                     
                                                                                                
  QDRANT_URL="http://localhost:6333" \                      
  COLLECTION_NAME="my-codebase" \
  EMBEDDING_PROVIDER="openrouter" \                                                             
  OPENROUTER_API_KEY="sk-or-..." \
  EMBEDDING_MODEL="text-embedding-3-small" \                                                    
  uvx mcp-server-qdrant                                     
                           