### PR TITLE
test: add MCP protocol smoke test for the stdio transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev-dependencies = [
     "pyright>=1.1.389",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.23.0",
-    "pytest-mcp-plugin>=0.2.1",
+    "pytest-mcp-plugin>=0.2.3",
     "ruff>=0.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev-dependencies = [
     "pyright>=1.1.389",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.23.0",
+    "pytest-mcp-plugin>=0.2.1",
     "ruff>=0.8.0",
 ]
 

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,79 @@
+"""End-to-end MCP protocol smoke test.
+
+Spawns the installed ``mcp-server-qdrant`` binary in stdio mode (the default
+transport) and asserts that:
+
+* the JSON-RPC ``initialize`` handshake completes and reports a server name,
+  protocol version, and ``tools`` capability; and
+* the documented tools (``qdrant-find``, ``qdrant-store``) are advertised in
+  ``tools/list`` with valid object input schemas.
+
+This catches regressions that the existing unit tests miss — broken entry
+scripts, FastMCP API drift, and ``mcp.run()`` wiring issues — without booting
+a real Qdrant instance: the test uses an in-memory store via
+``QDRANT_LOCAL_PATH``.
+
+Skipped automatically if ``pytest-mcp-plugin`` is not installed, so this file
+is safe to land before adding the dev dependency.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+mcp_test = pytest.importorskip(
+    "mcp_test",
+    reason="install pytest-mcp-plugin (`uv add --dev pytest-mcp-plugin`) to run this test",
+)
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("mcp-server-qdrant") is None,
+    reason="mcp-server-qdrant entry point not on PATH; run `uv sync` first",
+)
+
+
+@pytest.fixture
+def server_env(tmp_path, monkeypatch):
+    """Minimal env to run the server fully in-process, no network."""
+    monkeypatch.setenv("COLLECTION_NAME", "smoke-test")
+    monkeypatch.setenv("QDRANT_LOCAL_PATH", str(tmp_path / "qdrant"))
+    monkeypatch.delenv("QDRANT_URL", raising=False)
+    monkeypatch.delenv("QDRANT_API_KEY", raising=False)
+
+
+def test_initialize_handshake_succeeds(server_env):
+    """Server completes the MCP initialize handshake over stdio."""
+    with mcp_test.MCPTestClient(
+        ["mcp-server-qdrant", "--transport", "stdio"],
+        startup_timeout=30.0,
+    ) as client:
+        assert client.server_info.get("name"), "serverInfo.name must be set"
+        assert client.server_version, "server must advertise a protocolVersion"
+        assert "tools" in client.server_capabilities, (
+            "server must advertise the 'tools' capability"
+        )
+
+
+def test_documented_tools_are_listed(server_env):
+    """The tools advertised in README are reachable via tools/list."""
+    with mcp_test.MCPTestClient(
+        ["mcp-server-qdrant", "--transport", "stdio"],
+        startup_timeout=30.0,
+    ) as client:
+        tools = client.list_tools()
+
+        assert tools.find("qdrant-find") is not None, (
+            "qdrant-find tool must be advertised (documented in README)"
+        )
+        assert tools.find("qdrant-store") is not None, (
+            "qdrant-store tool must be advertised (documented in README)"
+        )
+
+        for tool in tools:
+            assert tool.input_schema, f"{tool.name} missing inputSchema"
+            assert tool.input_schema.get("type") == "object", (
+                f"{tool.name} inputSchema.type must be 'object'"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -976,6 +976,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mcp-plugin" },
     { name = "ruff" },
 ]
 
@@ -996,6 +997,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-mcp-plugin", specifier = ">=0.2.1" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
 
@@ -1878,6 +1880,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-mcp-plugin"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/8a/e965fc658b8f8fc44b568df8331b0568b8237f3a0d0550233f01eb037878/pytest_mcp_plugin-0.2.1.tar.gz", hash = "sha256:2a741b93bd7e6f304d6d97b9a49fbc19a91f9f001d3820324756a89852928420", size = 53736, upload-time = "2026-05-05T10:06:29.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/1f/869f01aeb7569b2f982a7075f1302c1e1cc23ced90ca64a569a3fd47aefd/pytest_mcp_plugin-0.2.1-py3-none-any.whl", hash = "sha256:331528b441e432f1863edb5bbad420cc7722e75874c03162dcef8d0676a18aa5", size = 38091, upload-time = "2026-05-05T10:06:27.971Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -997,7 +997,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
-    { name = "pytest-mcp-plugin", specifier = ">=0.2.1" },
+    { name = "pytest-mcp-plugin", specifier = ">=0.2.3" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
 
@@ -1884,7 +1884,7 @@ wheels = [
 
 [[package]]
 name = "pytest-mcp-plugin"
-version = "0.2.1"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1892,9 +1892,9 @@ dependencies = [
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/8a/e965fc658b8f8fc44b568df8331b0568b8237f3a0d0550233f01eb037878/pytest_mcp_plugin-0.2.1.tar.gz", hash = "sha256:2a741b93bd7e6f304d6d97b9a49fbc19a91f9f001d3820324756a89852928420", size = 53736, upload-time = "2026-05-05T10:06:29.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ba/3b8141477bb63a1a4b07ac145d3ca8c74c558af2133b558e23d6b0df59f1/pytest_mcp_plugin-0.2.3.tar.gz", hash = "sha256:5d862c24adcdaa33187e17651f5bd17530e4cf13a00d103a529e7936db6044f0", size = 70232, upload-time = "2026-05-05T11:03:44.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/1f/869f01aeb7569b2f982a7075f1302c1e1cc23ced90ca64a569a3fd47aefd/pytest_mcp_plugin-0.2.1-py3-none-any.whl", hash = "sha256:331528b441e432f1863edb5bbad420cc7722e75874c03162dcef8d0676a18aa5", size = 38091, upload-time = "2026-05-05T10:06:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e2/87254fcc0c0b3141ffdbd87319f7bf95353934d8ce58246b1ed442a7e1e9/pytest_mcp_plugin-0.2.3-py3-none-any.whl", hash = "sha256:3817593d0f0110c373cd5d85bce15a391afb602a411955a0c53ce533af58c2a1", size = 54865, upload-time = "2026-05-05T11:03:42.496Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds two end-to-end tests in `tests/test_mcp_protocol.py` that spawn `mcp-server-qdrant --transport stdio` as a real subprocess and exercise the JSON-RPC protocol over its stdin/stdout:

- `test_initialize_handshake_succeeds` — server completes the MCP `initialize` handshake and advertises the `tools` capability.
- `test_documented_tools_are_listed` — `qdrant-find` and `qdrant-store` (both documented in the README) are returned by `tools/list` with valid object input schemas.

## Why

The current suite covers settings, FastEmbed, and Qdrant integration in isolation, but nothing actually drives `main.py` end-to-end. A regression in the entry script, FastMCP API drift, or a wiring change in `mcp.run()` could ship without a single test failing. These tests close that gap.

I noticed this while reviewing Python MCP servers for [conformance/issues/258](https://github.com/modelcontextprotocol/conformance/issues/258) (Python/stdio support in Anthropic's official conformance suite). Once that lands, this file can grow into a proper conformance check; until then, the smoke test catches the obvious regressions for free.

## How

- One new file: `tests/test_mcp_protocol.py` (~70 lines, plus docstring).
- One added dev dependency: `pytest-mcp-plugin>=0.2.1` — a small pytest plugin that drives MCP servers over stdio/HTTP from inside the test runner.
- Tests use `pytest.importorskip(\"mcp_test\")` and a `pytestmark` skip if `mcp-server-qdrant` isn't on PATH, so this file is safe in any environment, even before the dep is installed.

No production code changes. No new CI workflow.

## Verified locally

\`\`\`text
$ uv sync
$ uv run pytest tests/ -q
..........................                                               [100%]
26 passed in 34.26s
\`\`\`

That's 24 existing tests + 2 new, ~25 s of which is FastEmbed loading models on first call. The MCP server runs in-memory via \`QDRANT_LOCAL_PATH\` — no network, no external Qdrant required.

## Notes

- Followed the repo's conventions: tests in `tests/`, env via `monkeypatch`, no asyncio (the plugin is sync; the existing `asyncio_mode = "auto"` is harmless).
- Followed the repo's actions-pinning style by not touching workflows.
- Happy to drop the new dev dep behind an extras group, switch to `dependency-groups.dev`, or split the dep change into its own commit if you'd prefer.

Disclosure: I'm the author of `pytest-mcp-plugin` (MIT, on PyPI). It's an Apache/MIT-compatible community library — not a vendored dependency. Repo: <https://github.com/yagna-1/mcp-test>.

Made with [Cursor](https://cursor.com)