### PR TITLE
feat: support QDRANT_URL with path prefix for reverse proxy deployments

### DIFF
--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -47,9 +47,24 @@ class QdrantConnector:
         self._qdrant_api_key = qdrant_api_key
         self._default_collection_name = collection_name
         self._embedding_provider = embedding_provider
-        self._client = AsyncQdrantClient(
-            location=qdrant_url, api_key=qdrant_api_key, path=qdrant_local_path
-        )
+
+        # Support URL with path prefix (e.g., https://host.com/qdrant)
+        client_kwargs = {"api_key": qdrant_api_key, "path": qdrant_local_path}
+        if qdrant_url and not qdrant_local_path:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(qdrant_url.rstrip("/"))
+            prefix = parsed.path.lstrip("/") if parsed.path and parsed.path != "/" else None
+            if prefix:
+                base_url = f"{parsed.scheme}://{parsed.hostname}"
+                port = parsed.port or (443 if parsed.scheme == "https" else 80)
+                client_kwargs.update({"location": base_url, "port": port, "prefix": prefix})
+            else:
+                client_kwargs["location"] = qdrant_url
+        else:
+            client_kwargs["location"] = qdrant_url
+
+        self._client = AsyncQdrantClient(**client_kwargs)
         self._field_indexes = field_indexes
 
     async def get_collection_names(self) -> list[str]:

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_server_qdrant.qdrant import QdrantConnector
+
+
+class TestUrlParsing:
+    """Test that Qdrant URLs are correctly parsed into location, port, and prefix."""
+
+    @patch("mcp_server_qdrant.qdrant.AsyncQdrantClient")
+    def test_url_with_path_prefix(self, mock_client_cls):
+        """Test that a URL with a path prefix is parsed into location, port, and prefix."""
+        mock_client_cls.return_value = AsyncMock()
+        embedding_provider = AsyncMock()
+
+        QdrantConnector(
+            qdrant_url="https://host.com/qdrant",
+            qdrant_api_key=None,
+            collection_name="test",
+            embedding_provider=embedding_provider,
+        )
+
+        mock_client_cls.assert_called_once_with(
+            api_key=None,
+            path=None,
+            location="https://host.com",
+            port=443,
+            prefix="qdrant",
+        )
+
+    @patch("mcp_server_qdrant.qdrant.AsyncQdrantClient")
+    def test_url_without_path(self, mock_client_cls):
+        """Test that a URL without a path is passed directly as location."""
+        mock_client_cls.return_value = AsyncMock()
+        embedding_provider = AsyncMock()
+
+        QdrantConnector(
+            qdrant_url="http://localhost:6333",
+            qdrant_api_key=None,
+            collection_name="test",
+            embedding_provider=embedding_provider,
+        )
+
+        mock_client_cls.assert_called_once_with(
+            api_key=None,
+            path=None,
+            location="http://localhost:6333",
+        )
+
+    @patch("mcp_server_qdrant.qdrant.AsyncQdrantClient")
+    def test_url_with_custom_port_and_prefix(self, mock_client_cls):
+        """Test that a URL with an explicit port and path prefix extracts the port correctly."""
+        mock_client_cls.return_value = AsyncMock()
+        embedding_provider = AsyncMock()
+
+        QdrantConnector(
+            qdrant_url="https://host.com:8443/qdrant",
+            qdrant_api_key=None,
+            collection_name="test",
+            embedding_provider=embedding_provider,
+        )
+
+        mock_client_cls.assert_called_once_with(
+            api_key=None,
+            path=None,
+            location="https://host.com",
+            port=8443,
+            prefix="qdrant",
+        )


### PR DESCRIPTION
## Summary
When Qdrant is behind a reverse proxy with a path-based route 
(e.g. `https://myhost.com/qdrant`), the current `AsyncQdrantClient` 
initialization fails because it doesn't handle the path prefix.

## Changes
- Parse `QDRANT_URL` to detect path prefix
- Pass `prefix`, `port`, and base `location` separately to `AsyncQdrantClient`
- URLs without a path continue to work as before (no breaking change)

## Tested with
- Qdrant behind Nginx at `https://host.com/qdrant` (port 443)
- Standard `http://localhost:6333` (no prefix, unchanged behavior)

Fixes #135 