### PR TITLE
fix: support qdrant url path prefixes

### DIFF
--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel
 from qdrant_client import AsyncQdrantClient, models
@@ -47,8 +48,11 @@ class QdrantConnector:
         self._qdrant_api_key = qdrant_api_key
         self._default_collection_name = collection_name
         self._embedding_provider = embedding_provider
+        client_url_options = build_qdrant_client_url_options(qdrant_url)
         self._client = AsyncQdrantClient(
-            location=qdrant_url, api_key=qdrant_api_key, path=qdrant_local_path
+            **client_url_options,
+            api_key=qdrant_api_key,
+            path=qdrant_local_path,
         )
         self._field_indexes = field_indexes
 
@@ -168,3 +172,34 @@ class QdrantConnector:
                         field_name=field_name,
                         field_schema=field_type,
                     )
+
+
+def build_qdrant_client_url_options(
+    qdrant_url: str | None,
+) -> dict[str, str | int | None]:
+    """
+    Build Qdrant client URL options from QDRANT_URL.
+
+    AsyncQdrantClient accepts reverse-proxy deployments as a base URL plus a
+    separate prefix. Passing a URL with a path via `location` loses the prefix.
+    """
+    if not qdrant_url:
+        return {"location": qdrant_url}
+
+    stripped_url = qdrant_url.rstrip("/")
+    parsed_url = urlsplit(stripped_url)
+
+    if not parsed_url.scheme or not parsed_url.netloc or not parsed_url.path:
+        return {"location": stripped_url}
+
+    base_url = urlunsplit((parsed_url.scheme, parsed_url.netloc, "", "", ""))
+    prefix = f"/{parsed_url.path.strip('/')}"
+    options: dict[str, str | int | None] = {"url": base_url, "prefix": prefix}
+
+    if parsed_url.port is None:
+        if parsed_url.scheme == "https":
+            options["port"] = 443
+        elif parsed_url.scheme == "http":
+            options["port"] = 80
+
+    return options

--- a/tests/test_qdrant_client_options.py
+++ b/tests/test_qdrant_client_options.py
@@ -1,0 +1,66 @@
+from mcp_server_qdrant.qdrant import (
+    QdrantConnector,
+    build_qdrant_client_url_options,
+)
+
+
+def test_qdrant_url_without_path_uses_location():
+    assert build_qdrant_client_url_options("https://example.com:6333") == {
+        "location": "https://example.com:6333"
+    }
+
+
+def test_qdrant_url_with_path_prefix_uses_url_and_prefix():
+    assert build_qdrant_client_url_options("https://example.com/qdrant") == {
+        "url": "https://example.com",
+        "prefix": "/qdrant",
+        "port": 443,
+    }
+
+
+def test_qdrant_http_url_with_path_prefix_uses_http_port():
+    assert build_qdrant_client_url_options("http://example.com/qdrant") == {
+        "url": "http://example.com",
+        "prefix": "/qdrant",
+        "port": 80,
+    }
+
+
+def test_qdrant_url_with_port_and_nested_path_prefix():
+    assert build_qdrant_client_url_options(
+        "http://example.com:8443/vector/qdrant/"
+    ) == {
+        "url": "http://example.com:8443",
+        "prefix": "/vector/qdrant",
+    }
+
+
+def test_qdrant_non_http_location_is_preserved():
+    assert build_qdrant_client_url_options(":memory:") == {"location": ":memory:"}
+
+
+def test_connector_passes_reverse_proxy_prefix_to_client(monkeypatch):
+    captured_options = {}
+
+    class StubQdrantClient:
+        def __init__(self, **kwargs):
+            captured_options.update(kwargs)
+
+    monkeypatch.setattr(
+        "mcp_server_qdrant.qdrant.AsyncQdrantClient", StubQdrantClient
+    )
+
+    QdrantConnector(
+        qdrant_url="https://example.com/qdrant",
+        qdrant_api_key="secret",
+        collection_name="memories",
+        embedding_provider=object(),
+    )
+
+    assert captured_options == {
+        "url": "https://example.com",
+        "prefix": "/qdrant",
+        "port": 443,
+        "api_key": "secret",
+        "path": None,
+    }


### PR DESCRIPTION
## Summary

Fixes QDRANT_URL values that include a reverse-proxy path prefix, such as `https://example.com/qdrant`.

## Problem

When the server runs behind Kubernetes ingress, Nginx, Traefik, or another reverse proxy, Qdrant may be exposed under a path prefix and standard HTTP(S) ports. Passing that URL through as a plain client location keeps the default Qdrant port and can make the client connect to the wrong endpoint.

## Changes

- Split prefixed QDRANT_URL values into a base `url` and Qdrant client `prefix`.
- Use standard ports for prefixed `https` and `http` URLs when no explicit port is present.
- Preserve existing behavior for regular Qdrant URLs, explicit ports, `:memory:`, and local-path mode.
- Added tests for prefixed URLs, explicit ports, and connector option forwarding.

Fixes #135.

## Validation

- `.venv\Scripts\python.exe -m pytest tests\test_qdrant_client_options.py`
- `.venv\Scripts\ruff.exe check src\mcp_server_qdrant\qdrant.py tests\test_qdrant_client_options.py`
- `.venv\Scripts\python.exe -m py_compile src\mcp_server_qdrant\qdrant.py tests\test_qdrant_client_options.py`