### PR TITLE
fix: add regression test for optional qdrant-store metadata

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,64 @@
+import pytest
+from fastmcp import Client
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+from mcp_server_qdrant.mcp_server import QdrantMCPServer
+from mcp_server_qdrant.settings import QdrantSettings, ToolSettings
+
+
+class DummyEmbeddingProvider(EmbeddingProvider):
+    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in documents]
+
+    async def embed_query(self, query: str) -> list[float]:
+        return [0.0]
+
+    def get_vector_name(self) -> str:
+        return "dummy-vector"
+
+    def get_vector_size(self) -> int:
+        return 1
+
+
+class DummyQdrantConnector:
+    instances: list["DummyQdrantConnector"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.store_calls = []
+        DummyQdrantConnector.instances.append(self)
+
+    async def store(self, entry, *, collection_name=None):
+        self.store_calls.append((entry, collection_name))
+
+    async def search(self, query, *, collection_name=None, limit=10, query_filter=None):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_qdrant_store_allows_omitting_metadata(monkeypatch):
+    DummyQdrantConnector.instances.clear()
+    monkeypatch.setattr(
+        "mcp_server_qdrant.mcp_server.QdrantConnector", DummyQdrantConnector
+    )
+
+    server = QdrantMCPServer(
+        tool_settings=ToolSettings(),
+        qdrant_settings=QdrantSettings(collection_name="memories"),
+        embedding_provider=DummyEmbeddingProvider(),
+    )
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "qdrant-store",
+            {
+                "information": "remember this",
+            },
+        )
+
+    connector = DummyQdrantConnector.instances[0]
+    entry, collection_name = connector.store_calls[0]
+
+    assert result.data == "Remembered: remember this in collection memories"
+    assert entry.content == "remember this"
+    assert entry.metadata is None
+    assert collection_name == "memories"


### PR DESCRIPTION
## Summary
Add a focused regression test for `qdrant-store` so storing content without a `metadata` argument stays supported. The test drives the server through a real FastMCP client and verifies the connector still receives `metadata=None`.
## Why it matters
`src/mcp_server_qdrant/mcp_server.py` already documents that the `metadata` parameter shape is client-sensitive, especially for MCP clients such as Cursor. Without coverage, a refactor can silently make `metadata` required or stop passing `None`, breaking normal store calls from clients that omit the field.
## Testing
Added `tests/test_mcp_server.py` with an async regression test that instantiates `QdrantMCPServer` against a mocked connector and calls `qdrant-store` through `fastmcp.Client`. The assertion checks both the returned confirmation message and that the stored `Entry` still carries `metadata=None`.