### PR TITLE
feat: add Ollama embedding provider for local models

### DIFF
--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -13,5 +13,12 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
         return FastEmbedProvider(settings.model_name)
+    elif settings.provider_type == EmbeddingProviderType.OLLAMA:
+        from mcp_server_qdrant.embeddings.ollama import OllamaProvider
+
+        return OllamaProvider(
+            model_name=settings.model_name,
+            base_url=settings.ollama_base_url or "http://localhost:11434",
+        )
     else:
         raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/ollama.py
+++ b/src/mcp_server_qdrant/embeddings/ollama.py
@@ -1,0 +1,64 @@
+"""
+Ollama embedding provider for local embedding models.
+
+Uses the Ollama API to generate embeddings locally without external API keys.
+Supports any model available in Ollama (e.g., bge-m3, nomic-embed-text, mxbai-embed-large).
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+
+
+class OllamaProvider(EmbeddingProvider):
+    """
+    Ollama implementation of the embedding provider.
+    
+    :param model_name: The name of the Ollama model to use (e.g., "bge-m3").
+    :param base_url: The base URL of the Ollama API (default: "http://localhost:11434").
+    """
+
+    def __init__(self, model_name: str, base_url: str = "http://localhost:11434"):
+        self.model_name = model_name
+        self.base_url = base_url.rstrip("/")
+        self._vector_size: int | None = None
+
+    async def _embed(self, texts: list[str], input_type: str = "search_document") -> list[list[float]]:
+        """Embed a list of texts using the Ollama API."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/api/embed",
+                json={
+                    "model": self.model_name,
+                    "input": texts,
+                },
+                timeout=60.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["embeddings"]
+
+    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
+        """Embed a list of documents into vectors."""
+        return await self._embed(documents, input_type="search_document")
+
+    async def embed_query(self, query: str) -> list[float]:
+        """Embed a query into a vector."""
+        embeddings = await self._embed([query], input_type="search_query")
+        return embeddings[0]
+
+    def get_vector_name(self) -> str:
+        """Return the name of the vector for the Qdrant collection."""
+        model_name = self.model_name.split("/")[-1].lower()
+        return f"ollama-{model_name}"
+
+    async def get_vector_size(self) -> int:
+        """Get the size of the vector for the Qdrant collection."""
+        if self._vector_size is None:
+            # Embed a dummy text to get the vector size
+            embeddings = await self._embed(["test"])
+            self._vector_size = len(embeddings[0])
+        return self._vector_size

--- a/src/mcp_server_qdrant/embeddings/types.py
+++ b/src/mcp_server_qdrant/embeddings/types.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class EmbeddingProviderType(Enum):
     FASTEMBED = "fastembed"
+    OLLAMA = "ollama"

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -46,6 +46,10 @@ class EmbeddingProviderSettings(BaseSettings):
         default="sentence-transformers/all-MiniLM-L6-v2",
         validation_alias="EMBEDDING_MODEL",
     )
+    ollama_base_url: str | None = Field(
+        default=None,
+        validation_alias="OLLAMA_BASE_URL",
+    )
 
 
 class FilterableField(BaseModel):


### PR DESCRIPTION
## What

Adds Ollama as an embedding provider alongside FastEmbed, enabling local embedding models without external API keys.

## Why

From [#62](https://github.com/qdrant/mcp-server-qdrant/issues/62): "Being stuck with fastembed only means this mcp server won't work at all for a lot of us. I'm using Ollama/bge-m3:latest" — @magnus919

@kacperlukawski confirmed: "We have a pretty flexible interface, so adding a new embedding model should not be a big deal. Please feel free to open a PR."

## How

### New file: `src/mcp_server_qdrant/embeddings/ollama.py`

```python
class OllamaProvider(EmbeddingProvider):
    """Ollama implementation using /api/embed endpoint."""
    
    def __init__(self, model_name: str, base_url: str = "http://localhost:11434"):
        ...
    
    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
        return await self._embed(documents, input_type="search_document")
    
    async def embed_query(self, query: str) -> list[float]:
        return (await self._embed([query], input_type="search_query"))[0]
```

### Updated files:

- `types.py` — Add `OLLAMA = "ollama"` to `EmbeddingProviderType`
- `factory.py` — Add `OLLAMA` case to `create_embedding_provider()`
- `settings.py` — Add `ollama_base_url` field (env: `OLLAMA_BASE_URL`)

## Usage

```bash
# .env
EMBEDDING_PROVIDER=ollama
EMBEDDING_MODEL=bge-m3
OLLAMA_BASE_URL=http://localhost:11434
```

Or with any Ollama-compatible model:

```bash
EMBEDDING_PROVIDER=ollama
EMBEDDING_MODEL=nomic-embed-text
```

## Testing

```bash
# Start Ollama
ollama serve
ollama pull bge-m3

# Run MCP server
EMBEDDING_PROVIDER=ollama EMBEDDING_MODEL=bge-m3 python -m mcp_server_qdrant
```

## Design decisions

1. **Uses `/api/embed` endpoint** — Ollama's native embedding API, supports batch embedding
2. **Auto-detects vector size** — Embeds a dummy text on first call to get dimensions
3. **Separate base_url setting** — Allows connecting to remote Ollama instances
4. **Async with httpx** — Non-blocking I/O, consistent with FastEmbed provider

## Ref

Closes #62