### PR TITLE
feat: add OpenAI-compatible embedding provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,28 +47,72 @@ Configuration is done via environment variables. The only command-line argument 
 | `QDRANT_API_KEY`         | API key for the Qdrant server                                       | None                                                              |
 | `COLLECTION_NAME`        | Name of the default collection to use.                              | None                                                              |
 | `QDRANT_LOCAL_PATH`      | Path to the local Qdrant database (alternative to `QDRANT_URL`)     | None                                                              |
-| `EMBEDDING_PROVIDER`     | Embedding provider to use (currently only "fastembed" is supported) | `fastembed`                                                       |
+| `EMBEDDING_PROVIDER`     | Embedding provider to use (`fastembed` or `openai`)                 | `fastembed`                                                       |
 | `EMBEDDING_MODEL`        | Name of the embedding model to use                                  | `sentence-transformers/all-MiniLM-L6-v2`                          |
 | `TOOL_STORE_DESCRIPTION` | Custom description for the store tool                               | See default in [`settings.py`](src/mcp_server_qdrant/settings.py) |
 | `TOOL_FIND_DESCRIPTION`  | Custom description for the find tool                                | See default in [`settings.py`](src/mcp_server_qdrant/settings.py) |
 | `QDRANT_SEARCH_LIMIT`    | Maximum number of results to return from search                     | `10`                                                              |
 | `QDRANT_READ_ONLY`       | Enable read-only mode (disables `qdrant-store` tool)                | `false`                                                           |
 
+### OpenAI-compatible embedding providers
+
+When `EMBEDDING_PROVIDER=openai`, the server uses any OpenAI-compatible embeddings endpoint instead of
+[FastEmbed](https://qdrant.github.io/fastembed/). This works with OpenAI directly, or any compatible provider such as
+[OpenRouter](https://openrouter.ai/), Azure OpenAI, Together AI, and others.
+
+| Name                 | Description                                                                                                                          | Default Value               |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `OPENAI_API_KEY`     | API key for the OpenAI-compatible embedding service                                                                                  | None                        |
+| `OPENAI_BASE_URL`    | Base URL of the OpenAI-compatible endpoint                                                                                           | `https://api.openai.com/v1` |
+| `OPENAI_VECTOR_SIZE` | Dimensionality of the embedding vectors. When omitted, the server probes the API once at startup to discover the size automatically. | None (auto-detected)        |
+
+#### Example: OpenAI
+
+```shell
+QDRANT_URL="http://localhost:6333" \
+COLLECTION_NAME="my-collection" \
+EMBEDDING_PROVIDER="openai" \
+OPENAI_API_KEY="sk-..." \
+EMBEDDING_MODEL="text-embedding-3-small" \
+OPENAI_VECTOR_SIZE=1536 \
+uvx mcp-server-qdrant
+```
+
+#### Example: OpenRouter
+
+[OpenRouter](https://openrouter.ai/) provides access to a wide range of embedding models through a single
+OpenAI-compatible API, including multilingual models well-suited for non-English content.
+
+```shell
+QDRANT_URL="http://localhost:6333" \
+COLLECTION_NAME="my-collection" \
+EMBEDDING_PROVIDER="openai" \
+OPENAI_API_KEY="sk-or-v1-..." \
+OPENAI_BASE_URL="https://openrouter.ai/api/v1" \
+EMBEDDING_MODEL="qwen/qwen3-embedding-0.6b" \
+OPENAI_VECTOR_SIZE=1024 \
+uvx mcp-server-qdrant
+```
+
+> [!TIP]
+> Set `OPENAI_VECTOR_SIZE` explicitly to match your Qdrant collection dimensions and skip the startup probe request.
+> If omitted, the server will make one test embedding call at startup to determine the vector size automatically.
+
 ### FastMCP Environment Variables
 
 Since `mcp-server-qdrant` is based on FastMCP, it also supports all the FastMCP environment variables. The most
 important ones are listed below:
 
-| Environment Variable                       | Description                                                     | Default Value |
-|--------------------------------------------|-----------------------------------------------------------------|---------------|
-| `FASTMCP_LOG_LEVEL`                        | Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)       | `INFO`        |
-| `FASTMCP_SERVER_DEBUG`                     | Enable debug mode                                               | `false`       |
-| `FASTMCP_SERVER_HOST`                      | Host address to bind the server to                              | `127.0.0.1`   |
-| `FASTMCP_SERVER_PORT`                      | Port to run the server on                                       | `8000`        |
-| `FASTMCP_SERVER_ON_DUPLICATE_RESOURCES`    | Behavior for duplicate resources (warn, error, replace, ignore) | `warn`        |
-| `FASTMCP_SERVER_ON_DUPLICATE_TOOLS`        | Behavior for duplicate tools (warn, error, replace, ignore)     | `warn`        |
-| `FASTMCP_SERVER_ON_DUPLICATE_PROMPTS`      | Behavior for duplicate prompts (warn, error, replace, ignore)   | `warn`        |
-| `FASTMCP_SERVER_DEPENDENCIES`              | List of dependencies to install in the server environment       | `[]`          |
+| Environment Variable                    | Description                                                     | Default Value |
+|-----------------------------------------|-----------------------------------------------------------------|---------------|
+| `FASTMCP_LOG_LEVEL`                     | Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)       | `INFO`        |
+| `FASTMCP_SERVER_DEBUG`                  | Enable debug mode                                               | `false`       |
+| `FASTMCP_SERVER_HOST`                   | Host address to bind the server to                              | `127.0.0.1`   |
+| `FASTMCP_SERVER_PORT`                   | Port to run the server on                                       | `8000`        |
+| `FASTMCP_SERVER_ON_DUPLICATE_RESOURCES` | Behavior for duplicate resources (warn, error, replace, ignore) | `warn`        |
+| `FASTMCP_SERVER_ON_DUPLICATE_TOOLS`     | Behavior for duplicate tools (warn, error, replace, ignore)     | `warn`        |
+| `FASTMCP_SERVER_ON_DUPLICATE_PROMPTS`   | Behavior for duplicate prompts (warn, error, replace, ignore)   | `warn`        |
+| `FASTMCP_SERVER_DEPENDENCIES`           | List of dependencies to install in the server environment       | `[]`          |
 
 > [!NOTE]
 > Server-specific settings use the `FASTMCP_SERVER_` prefix. This may change in future versions.
@@ -181,8 +225,9 @@ For local Qdrant mode:
 
 This MCP server will automatically create a collection with the specified name if it doesn't exist.
 
-By default, the server will use the `sentence-transformers/all-MiniLM-L6-v2` embedding model to encode memories.
-For the time being, only [FastEmbed](https://qdrant.github.io/fastembed/) models are supported.
+By default, the server will use the `sentence-transformers/all-MiniLM-L6-v2` embedding model via
+[FastEmbed](https://qdrant.github.io/fastembed/). To use OpenAI or any OpenAI-compatible provider instead, set
+`EMBEDDING_PROVIDER=openai` and the relevant `OPENAI_*` variables described above.
 
 ## Support for other tools
 
@@ -207,7 +252,7 @@ TOOL_FIND_DESCRIPTION="Search for relevant code snippets based on natural langua
 The 'query' parameter should describe what you're looking for, \
 and the tool will return the most relevant code snippets. \
 Use this when you need to find existing code snippets for reuse or reference." \
-uvx mcp-server-qdrant --transport sse # Enable SSE transport
+uvx mcp-server-qdrant --transport sse
 ```
 
 In Cursor/Windsurf, you can then configure the MCP server in your settings by pointing to this running server using
@@ -253,7 +298,6 @@ existing codebase.
 1. Add the MCP server to Claude Code:
 
     ```shell
-    # Add mcp-server-qdrant configured for code search
     claude mcp add code-search \
     -e QDRANT_URL="http://localhost:6333" \
     -e COLLECTION_NAME="code-repository" \
@@ -303,22 +347,9 @@ Add the following JSON block to your User Settings (JSON) file in VS Code. You c
 {
   "mcp": {
     "inputs": [
-      {
-        "type": "promptString",
-        "id": "qdrantUrl",
-        "description": "Qdrant URL"
-      },
-      {
-        "type": "promptString",
-        "id": "qdrantApiKey",
-        "description": "Qdrant API Key",
-        "password": true
-      },
-      {
-        "type": "promptString",
-        "id": "collectionName",
-        "description": "Collection Name"
-      }
+      {"type": "promptString", "id": "qdrantUrl", "description": "Qdrant URL"},
+      {"type": "promptString", "id": "qdrantApiKey", "description": "Qdrant API Key", "password": true},
+      {"type": "promptString", "id": "collectionName", "description": "Collection Name"}
     ],
     "servers": {
       "qdrant": {
@@ -335,124 +366,19 @@ Add the following JSON block to your User Settings (JSON) file in VS Code. You c
 }
 ```
 
-Or if you prefer using Docker, add this configuration instead:
-
-```json
-{
-  "mcp": {
-    "inputs": [
-      {
-        "type": "promptString",
-        "id": "qdrantUrl",
-        "description": "Qdrant URL"
-      },
-      {
-        "type": "promptString",
-        "id": "qdrantApiKey",
-        "description": "Qdrant API Key",
-        "password": true
-      },
-      {
-        "type": "promptString",
-        "id": "collectionName",
-        "description": "Collection Name"
-      }
-    ],
-    "servers": {
-      "qdrant": {
-        "command": "docker",
-        "args": [
-          "run",
-          "-p", "8000:8000",
-          "-i",
-          "--rm",
-          "-e", "QDRANT_URL",
-          "-e", "QDRANT_API_KEY",
-          "-e", "COLLECTION_NAME",
-          "mcp-server-qdrant"
-        ],
-        "env": {
-          "QDRANT_URL": "${input:qdrantUrl}",
-          "QDRANT_API_KEY": "${input:qdrantApiKey}",
-          "COLLECTION_NAME": "${input:collectionName}"
-        }
-      }
-    }
-  }
-}
-```
-
-Alternatively, you can create a `.vscode/mcp.json` file in your workspace with the following content:
+Alternatively, you can create a `.vscode/mcp.json` file in your workspace:
 
 ```json
 {
   "inputs": [
-    {
-      "type": "promptString",
-      "id": "qdrantUrl",
-      "description": "Qdrant URL"
-    },
-    {
-      "type": "promptString",
-      "id": "qdrantApiKey",
-      "description": "Qdrant API Key",
-      "password": true
-    },
-    {
-      "type": "promptString",
-      "id": "collectionName",
-      "description": "Collection Name"
-    }
+    {"type": "promptString", "id": "qdrantUrl", "description": "Qdrant URL"},
+    {"type": "promptString", "id": "qdrantApiKey", "description": "Qdrant API Key", "password": true},
+    {"type": "promptString", "id": "collectionName", "description": "Collection Name"}
   ],
   "servers": {
     "qdrant": {
       "command": "uvx",
       "args": ["mcp-server-qdrant"],
-      "env": {
-        "QDRANT_URL": "${input:qdrantUrl}",
-        "QDRANT_API_KEY": "${input:qdrantApiKey}",
-        "COLLECTION_NAME": "${input:collectionName}"
-      }
-    }
-  }
-}
-```
-
-For workspace configuration with Docker, use this in `.vscode/mcp.json`:
-
-```json
-{
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "qdrantUrl",
-      "description": "Qdrant URL"
-    },
-    {
-      "type": "promptString",
-      "id": "qdrantApiKey",
-      "description": "Qdrant API Key",
-      "password": true
-    },
-    {
-      "type": "promptString",
-      "id": "collectionName",
-      "description": "Collection Name"
-    }
-  ],
-  "servers": {
-    "qdrant": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-p", "8000:8000",
-        "-i",
-        "--rm",
-        "-e", "QDRANT_URL",
-        "-e", "QDRANT_API_KEY",
-        "-e", "COLLECTION_NAME",
-        "mcp-server-qdrant"
-      ],
       "env": {
         "QDRANT_URL": "${input:qdrantUrl}",
         "QDRANT_API_KEY": "${input:qdrantApiKey}",

--- a/src/mcp_server_qdrant/embeddings/factory.py
+++ b/src/mcp_server_qdrant/embeddings/factory.py
@@ -13,5 +13,15 @@ def create_embedding_provider(settings: EmbeddingProviderSettings) -> EmbeddingP
         from mcp_server_qdrant.embeddings.fastembed import FastEmbedProvider
 
         return FastEmbedProvider(settings.model_name)
-    else:
-        raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")
+
+    if settings.provider_type == EmbeddingProviderType.OPENAI:
+        from mcp_server_qdrant.embeddings.openai import OpenAIEmbeddingProvider
+
+        return OpenAIEmbeddingProvider(
+            model_name=settings.model_name,
+            api_key=settings.api_key,
+            base_url=settings.base_url,
+            vector_size=settings.vector_size,
+        )
+
+    raise ValueError(f"Unsupported embedding provider: {settings.provider_type}")

--- a/src/mcp_server_qdrant/embeddings/openai.py
+++ b/src/mcp_server_qdrant/embeddings/openai.py
@@ -1,0 +1,77 @@
+from openai import AsyncOpenAI, OpenAI
+
+from mcp_server_qdrant.embeddings.base import EmbeddingProvider
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    """
+    OpenAI-compatible embedding provider.
+
+    Works with OpenAI directly or any compatible endpoint such as
+    OpenRouter, Azure OpenAI, Together AI, and so on.
+
+    :param model_name:  The embedding model to use (e.g. "text-embedding-3-small",
+                        "qwen/qwen3-embedding-0.6b" on OpenRouter).
+    :param api_key:     API key for the embedding service.
+    :param base_url:    Base URL of the OpenAI-compatible endpoint.
+                        Defaults to the official OpenAI API.
+    :param vector_size: Dimensionality of the embedding vectors.
+                        When None (default), the provider makes one synchronous
+                        probe request at startup to discover the actual size.
+                        Set this explicitly (e.g. 1024) to skip that probe.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: str | None = None,
+        base_url: str = "https://api.openai.com/v1",
+        vector_size: int | None = None,
+    ):
+        self.model_name = model_name
+        self._base_url = base_url
+
+        self._async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+        if vector_size is not None:
+            self._vector_size = vector_size
+        else:
+            # Probe once synchronously at startup to discover the vector size.
+            # This avoids maintaining a hard-coded lookup table and works with
+            # any model on any compatible endpoint.
+            sync_client = OpenAI(api_key=api_key, base_url=base_url)
+            response = sync_client.embeddings.create(
+                model=model_name,
+                input=["probe"],
+            )
+            self._vector_size = len(response.data[0].embedding)
+
+    async def embed_documents(self, documents: list[str]) -> list[list[float]]:
+        """Embed a list of documents into vectors."""
+        response = await self._async_client.embeddings.create(
+            model=self.model_name,
+            input=documents,
+        )
+        # The API returns items sorted by index, but sort explicitly to be safe.
+        return [item.embedding for item in sorted(response.data, key=lambda x: x.index)]
+
+    async def embed_query(self, query: str) -> list[float]:
+        """Embed a query into a vector."""
+        response = await self._async_client.embeddings.create(
+            model=self.model_name,
+            input=[query],
+        )
+        return response.data[0].embedding
+
+    def get_vector_name(self) -> str:
+        """
+        Return the name of the vector for the Qdrant collection.
+        Uses the last path segment of the model name, prefixed with 'openai-',
+        consistent with FastEmbed's 'fast-<model>' naming convention.
+        """
+        slug = self.model_name.split("/")[-1].lower()
+        return f"openai-{slug}"
+
+    def get_vector_size(self) -> int:
+        """Get the size of the vector for the Qdrant collection."""
+        return self._vector_size

--- a/src/mcp_server_qdrant/embeddings/types.py
+++ b/src/mcp_server_qdrant/embeddings/types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
 
-class EmbeddingProviderType(Enum):
+class EmbeddingProviderType(str, Enum):
     FASTEMBED = "fastembed"
+    OPENAI = "openai"

--- a/src/mcp_server_qdrant/settings.py
+++ b/src/mcp_server_qdrant/settings.py
@@ -47,6 +47,26 @@ class EmbeddingProviderSettings(BaseSettings):
         validation_alias="EMBEDDING_MODEL",
     )
 
+    # ── OpenAI-compatible provider settings ───────────────────────────────
+    # Used when EMBEDDING_PROVIDER=openai.
+    # api_key:   reads OPENAI_API_KEY; set to your OpenRouter / Azure / etc. key.
+    # base_url:  override to point at OpenRouter, Azure, or any compatible endpoint.
+    # vector_size: if omitted, the provider probes the API once at startup to
+    #              discover the actual dimension. Set it explicitly to skip that
+    #              probe and save one API call (e.g. OPENAI_VECTOR_SIZE=1024).
+    api_key: str | None = Field(
+        default=None,
+        validation_alias="OPENAI_API_KEY",
+    )
+    base_url: str = Field(
+        default="https://api.openai.com/v1",
+        validation_alias="OPENAI_BASE_URL",
+    )
+    vector_size: int | None = Field(
+        default=None,
+        validation_alias="OPENAI_VECTOR_SIZE",
+    )
+
 
 class FilterableField(BaseModel):
     name: str = Field(description="The name of the field payload field to filter on")


### PR DESCRIPTION
## Summary

Adds support for any OpenAI-compatible embeddings endpoint as an
alternative to fastembed. This allows users to use OpenAI, OpenRouter,
Azure OpenAI, Together AI, or any other compatible provider without
needing to run a local model.

## Changes

- `embeddings/types.py` — added `OPENAI` to `EmbeddingProviderType` enum
- `embeddings/openai.py` — new provider implementing `EmbeddingProvider`
- `embeddings/factory.py` — added openai branch to `create_embedding_provider`
- `settings.py` — added `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_VECTOR_SIZE` fields
- `README.md` — documented new env vars and usage examples

## New environment variables

| Variable | Description | Default |
|---|---|---|
| `OPENAI_API_KEY` | API key for the embedding service | None |
| `OPENAI_BASE_URL` | Base URL of the endpoint | `https://api.openai.com/v1` |
| `OPENAI_VECTOR_SIZE` | Vector dimensions (auto-detected if omitted) | None |

## Example (OpenRouter)

```shell
EMBEDDING_PROVIDER="openai" \
OPENAI_API_KEY="sk-or-v1-..." \
OPENAI_BASE_URL="https://openrouter.ai/api/v1" \
EMBEDDING_MODEL="qwen/qwen3-embedding-4b" \
OPENAI_VECTOR_SIZE=2560 \
uvx mcp-server-qdrant
```

## Testing

Tested locally with OpenRouter + `qwen/qwen3-embedding-4b` against
a local Qdrant instance. Both `qdrant-store` and `qdrant-find` tools
work correctly via MCP inspector.