### PR TITLE
chore: add smithery.yaml for Smithery deployment

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,38 @@
+# Smithery configuration file
+# https://smithery.ai/docs/build/project-config/smithery.yaml
+build:
+  dockerBuildPath: .
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP server.
+    type: object
+    required:
+      - qdrantUrl
+    properties:
+      qdrantUrl:
+        type: string
+        description: URL of the Qdrant server (e.g. https://xyz.cloud.qdrant.io:6333).
+      qdrantApiKey:
+        type: string
+        description: API key for the Qdrant server.
+      collectionName:
+        type: string
+        description: Name of the default collection to use.
+      embeddingModel:
+        type: string
+        default: sentence-transformers/all-MiniLM-L6-v2
+        description: FastEmbed model to use for embeddings.
+  commandFunction:
+    # Produces the CLI command that starts the MCP server on stdio.
+    |-
+    (config) => ({
+      command: 'mcp-server-qdrant',
+      args: ['--transport', 'stdio'],
+      env: {
+        QDRANT_URL: config.qdrantUrl,
+        QDRANT_API_KEY: config.qdrantApiKey || '',
+        COLLECTION_NAME: config.collectionName || '',
+        EMBEDDING_MODEL: config.embeddingModel || 'sentence-transformers/all-MiniLM-L6-v2'
+      }
+    })


### PR DESCRIPTION
## What

Adds a `smithery.yaml` project config so the server can be built and listed on [Smithery](https://smithery.ai), as requested in #93.

It uses the existing `Dockerfile` (`build.dockerBuildPath: .`) and runs the server as a **stdio** MCP server. The session `configSchema` exposes the standard options as user-provided config: `QDRANT_URL` (required), `QDRANT_API_KEY`, `COLLECTION_NAME`, and `EMBEDDING_MODEL` (defaulting to the current model).

## Notes

- No code changes: this is config only.
- `QDRANT_LOCAL_PATH` is intentionally omitted since local on-disk storage is not meaningful for a hosted Smithery deployment.
- Config format follows the current Smithery container/stdio spec.

Closes #93