### PR TITLE
fix: support Qdrant URL path prefixes

### DIFF
--- a/src/mcp_server_qdrant/qdrant.py
+++ b/src/mcp_server_qdrant/qdrant.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from typing import Any
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel
 from qdrant_client import AsyncQdrantClient, models
@@ -12,6 +13,28 @@ logger = logging.getLogger(__name__)
 
 Metadata = dict[str, Any]
 ArbitraryFilter = dict[str, Any]
+
+
+def qdrant_client_options(qdrant_url: str | None) -> dict[str, str]:
+    """Return Qdrant client options while preserving reverse-proxy prefixes."""
+    if not qdrant_url:
+        return {}
+
+    if qdrant_url == ":memory:":
+        return {"location": qdrant_url}
+
+    parsed = urlsplit(qdrant_url)
+    prefix = parsed.path.rstrip("/")
+    if not prefix:
+        return {"location": qdrant_url}
+
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("QDRANT_URL with a path prefix must include a scheme and host")
+
+    return {
+        "url": f"{parsed.scheme}://{parsed.netloc}",
+        "prefix": prefix,
+    }
 
 
 class Entry(BaseModel):
@@ -47,9 +70,20 @@ class QdrantConnector:
         self._qdrant_api_key = qdrant_api_key
         self._default_collection_name = collection_name
         self._embedding_provider = embedding_provider
-        self._client = AsyncQdrantClient(
-            location=qdrant_url, api_key=qdrant_api_key, path=qdrant_local_path
-        )
+        client_options = qdrant_client_options(qdrant_url)
+        if "url" in client_options:
+            self._client = AsyncQdrantClient(
+                url=client_options["url"],
+                prefix=client_options["prefix"],
+                api_key=qdrant_api_key,
+                path=qdrant_local_path,
+            )
+        else:
+            self._client = AsyncQdrantClient(
+                location=client_options.get("location"),
+                api_key=qdrant_api_key,
+                path=qdrant_local_path,
+            )
         self._field_indexes = field_indexes
 
     async def get_collection_names(self) -> list[str]:

--- a/tests/test_qdrant_client_options.py
+++ b/tests/test_qdrant_client_options.py
@@ -1,0 +1,25 @@
+import pytest
+
+from mcp_server_qdrant.qdrant import qdrant_client_options
+
+
+def test_qdrant_url_without_prefix_uses_location():
+    assert qdrant_client_options("https://qdrant.example.com:6333") == {
+        "location": "https://qdrant.example.com:6333"
+    }
+
+
+def test_in_memory_qdrant_uses_location():
+    assert qdrant_client_options(":memory:") == {"location": ":memory:"}
+
+
+def test_qdrant_url_with_prefix_uses_base_url_and_prefix():
+    assert qdrant_client_options("https://qdrant.example.com/qdrant/") == {
+        "url": "https://qdrant.example.com",
+        "prefix": "/qdrant",
+    }
+
+
+def test_qdrant_url_prefix_requires_absolute_url():
+    with pytest.raises(ValueError, match="scheme and host"):
+        qdrant_client_options("qdrant.example.com/qdrant")


### PR DESCRIPTION
Fixes #135. Preserve reverse-proxy path prefixes in QDRANT_URL while keeping normal URLs and :memory: mode unchanged. Tests: uv run pytest (28 passed), ruff format/check, uv build, git diff --check.