### PR TITLE
docs(kiro-power): cover env var approval and PATH pitfalls in setup skill

### DIFF
--- a/kiro-power/skills/setup/SKILL.md
+++ b/kiro-power/skills/setup/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: setup
-description: Configure the Qdrant Power after installation. Use this skill for missing uvx, missing environment variables, unavailable Qdrant tools, and setup requests.
+description: Configure the Qdrant Power after installation. Use this skill for missing uvx, missing environment variables, unapproved environment variables, unavailable Qdrant tools, "Failed to connect" errors, and setup requests.
 ---
 
 # Configure the Qdrant Power
 
 After the Power is installed, guide the user through these steps.
+
+Kiro IDE needs three separate things to be true before the server starts:
+
+1. `uvx` is reachable from the process that launched Kiro.
+2. The four variables exist in that process environment.
+3. The four variable names appear in Kiro's approved list.
+
+A failure in any one of them shows up as the same `Failed to connect` log line,
+so work through the steps in order instead of guessing.
 
 ## 1. Make sure that uvx is available
 
@@ -15,7 +24,11 @@ Run this command:
 uvx --version
 ```
 
-If the command succeeds, continue to the configuration.
+If the command succeeds, note the full path:
+
+```shell
+command -v uvx
+```
 
 If the command fails, tell the user that the Power requires uv.
 
@@ -28,6 +41,10 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 After the installation, run `uvx --version` again.
 
 If `uvx` is still unavailable, tell the user to restart the terminal and Kiro.
+
+CAUTION: `uv` installs `uvx` into `~/.local/bin`. A Kiro IDE started from the
+macOS Dock or Finder receives a minimal `PATH` of `/usr/bin:/bin:/usr/sbin:/sbin`
+and cannot resolve the bare `uvx` command. Step 5 covers this.
 
 ## 2. Collect the configuration
 
@@ -53,7 +70,7 @@ Tell the user that the server creates the collection automatically.
 
 CAUTION: Do not change the embedding model for an existing collection. A different vector size can cause store or search errors.
 
-## 3. Configure Kiro
+## 3. Set the environment variables
 
 Give the user this template with the selected values:
 
@@ -64,18 +81,100 @@ export COLLECTION_NAME="<collection-name>"
 export EMBEDDING_MODEL="sentence-transformers/all-MiniLM-L6-v2"
 ```
 
+Tell the user to put these lines in a shell startup file such as `~/.zshrc`, or
+in a file that a startup file sources. Variables typed at a prompt live only in
+that one terminal session.
+
+Tell the user to keep the API key out of shell history by editing the file
+directly instead of typing an `export` command at the prompt.
+
 Tell Kiro CLI users to export these variables before they start Kiro.
 
 Tell Kiro IDE users to set these variables in the environment that starts Kiro.
 
-If Kiro requests access, tell Kiro IDE users to approve the variables.
+## 4. Approve the variables in Kiro IDE
 
-After the user configures the variables, tell the user to restart Kiro or reconnect the Qdrant MCP server.
+Kiro IDE expands only approved environment variables in MCP config files. Until
+the four names are approved, `${QDRANT_URL}` and the others stay unexpanded and
+the server fails to start.
 
-## 4. Make sure that the connection operates
+When Kiro detects unapproved variables in an MCP server configuration, it shows
+a security warning that lists them. The user can approve them from that popup.
+
+To manage the list manually, tell the user to:
+
+1. Open Kiro settings.
+2. Search for `Mcp Approved Env Vars`.
+3. Add `QDRANT_URL`, `QDRANT_API_KEY`, `COLLECTION_NAME`, and `EMBEDDING_MODEL`.
+
+This setting keeps MCP servers from reading arbitrary environment variables.
+
+## 5. Restart Kiro
+
+Tell the user to quit Kiro completely and start it again.
+
+Reconnecting the MCP server is not enough. The parent Kiro process keeps the
+environment it was launched with, so a server restart reuses the same empty
+variables.
+
+On macOS, tell the user to launch Kiro from a terminal that has the variables:
+
+```shell
+source ~/.zshrc
+kiro
+```
+
+This also gives Kiro a full `PATH`, which lets it resolve `uvx`.
+
+If the user prefers to launch Kiro from the Dock or Finder, the bare `uvx`
+command will not resolve. Tell the user to set an absolute command path in the
+Power's MCP server entry instead, using the path from step 1:
+
+```json
+"command": "/Users/<user>/.local/bin/uvx"
+```
+
+## 6. Make sure that the connection operates
 
 After Qdrant reconnects, use `qdrant-find` with a harmless query.
 
 If the tool returns no memories, report that the connection operates and the collection is empty.
 
 If the tool returns an error, explain the error and repeat the applicable configuration step.
+
+The first start downloads the embedding model, which can take several seconds
+and may time out once. Tell the user to reconnect if that happens. Later starts
+use the cached model.
+
+## Troubleshooting `Failed to connect`
+
+Kiro logs this line for every startup failure. Use these checks to tell the
+causes apart.
+
+Confirm the variables reached the Kiro process. Replace `<pid>` with the Kiro
+process id from `pgrep -f "Kiro.app/Contents/MacOS"`:
+
+```shell
+ps eww -p <pid> | tr ' ' '\n' | grep -c '^QDRANT_'
+```
+
+A count of `0` means step 3, step 4, or step 5 is incomplete.
+
+Confirm Kiro can resolve the command:
+
+```shell
+ps eww -p <pid> | tr ' ' '\n' | grep '^PATH='
+```
+
+A `PATH` of `/usr/bin:/bin:/usr/sbin:/sbin` means Kiro was launched from the
+Dock or Finder and cannot find `uvx`. Apply step 5.
+
+Confirm the credentials and URL independently of Kiro:
+
+```shell
+curl -s -o /dev/null -w '%{http_code}\n' -H "api-key: $QDRANT_API_KEY" "$QDRANT_URL/collections"
+```
+
+`200` means the URL and key are good and the fault is in the Kiro
+configuration. Qdrant Cloud accepts the base URL with or without an explicit
+`:6333` port.


### PR DESCRIPTION
Targets the `kiro-power` branch so it can fold into #175 rather than landing separately. Thanks for the Power, @Anush008 — I installed it and hit three distinct setup failures that all produced the same log line, so this documents them.

Setting the four environment variables is not sufficient on Kiro IDE. Three conditions must hold, and every failure surfaces as `Failed to connect` with no further detail, which makes them hard to tell apart:

1. `uvx` is reachable from the process that launched Kiro.
2. The four variables exist in that process environment.
3. The four variable names are on Kiro IDE's approved list.

## Changes to `kiro-power/skills/setup/SKILL.md`

**Approved environment variables.** Kiro IDE expands only approved variables in MCP config files, so `${QDRANT_URL}` and the rest stay unexpanded until the names are added under the `Mcp Approved Env Vars` setting. This replaces the existing "If Kiro requests access, tell Kiro IDE users to approve the variables" line, which I found too indirect to act on — I had the variables set correctly and still could not tell that expansion was being withheld.

**PATH on Dock and Finder launches.** A Kiro started from the Dock or Finder gets `PATH=/usr/bin:/bin:/usr/sbin:/sbin`. Since `uv` installs `uvx` into `~/.local/bin`, the bare `uvx` command in `kiro-power/mcp.json` cannot be resolved and the server never spawns. Documents launching Kiro from a terminal, with an absolute `command` path as the alternative.

**Restart rather than reconnect.** The existing text offers "restart Kiro or reconnect the Qdrant MCP server" as equivalent. Reconnecting is not sufficient: the parent Kiro process keeps the environment it was launched with, so the server restarts with the same empty variables.

**Persist the exports.** Variables typed at a prompt live only in that terminal session, which is easy to miss when following the existing template.

**Troubleshooting section.** `ps eww` checks that separate the three causes, plus a `curl` check that validates URL and key independently of Kiro. Also notes the first start downloads the embedding model and may time out once.

## Verified

- Reproduced `uvx: command not found` under `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin`.
- Confirmed a running Dock-launched Kiro had exactly that `PATH` and zero `QDRANT_*` variables.
- Completed an MCP `initialize` handshake against `mcp-server-qdrant` 1.29.0 under that bare environment using an absolute `uvx` path and literal env values.
- After approving the four variables and restarting the IDE, `qdrant-find` and `qdrant-store` both load and return results against Qdrant Cloud.

## Left alone deliberately

`kiro-power/mcp.json` keeps the bare `uvx` command, since an absolute path in a shared manifest would break other installs. A wrapper script that resolves `uvx` itself would remove the manual edit for Dock users, but that felt out of scope here.