### PR TITLE
Add context-cost badge (188 tokens — among the leanest we measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mcp-server-qdrant: A Qdrant MCP server
 
 [![smithery badge](https://smithery.ai/badge/mcp-server-qdrant)](https://smithery.ai/protocol/mcp-server-qdrant)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fqdrant.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
 
 > The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that enables
 > seamless integration between LLM applications and external data sources and tools. Whether you're building an


### PR DESCRIPTION
One line: a shields.io badge showing what mcp-server-qdrant's tool schemas cost in context tokens — currently **188 tokens across 2 tools** (`qdrant-find`: 85, `qdrant-store`: 101), measured 2026-08-16. That places it among the leanest of the 57 popular MCP servers we measured (median: 2,636 tokens), which seemed worth letting your README say.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — the raw `tools/list` capture plus a pinned tokenizer (`o200k_base`), re-derivable in five lines from the published measurement: [results/qdrant/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/qdrant/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. If you'd rather own the number in your own CI instead, `sd2k/mcp-tokens-action` (badge support proposed in sd2k/mcp-tokens-action#5) does that — happy to open that PR instead.