### PR TITLE
Fix broken Smithery badge (returns HTTP 500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-server-qdrant: A Qdrant MCP server
 
-[![smithery badge](https://smithery.ai/badge/mcp-server-qdrant)](https://smithery.ai/protocol/mcp-server-qdrant)
+[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.qdrant/mcp-server-qdrant.svg)](https://skillselion.com/mcp/tool/io.github.qdrant/mcp-server-qdrant)
 
 > The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that enables
 > seamless integration between LLM applications and external data sources and tools. Whether you're building an


### PR DESCRIPTION
The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/mcp-server-qdrant   ->  500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem.

**What this PR does:** removes that one dead badge line, and offers ours in its place.

```markdown
[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/io.github.qdrant/mcp-server-qdrant.svg)](https://skillselion.com/mcp/tool/io.github.qdrant/mcp-server-qdrant)
```

We'd be happy to have ours sit there instead — Skillselion is an independent directory of agent skills and MCP servers, and this project is already listed at https://skillselion.com/mcp/tool/io.github.qdrant/mcp-server-qdrant whether or not you take the badge.

**Entirely your call, and no hard feelings either way:**
- Happy for the badge to stay → merge as is.
- Prefer the dead badge just gone → say so and I'll amend this to a removal-only change.
- Prefer nothing touched → close it, no reply needed.

Only the dead Smithery image was changed. Any other badges in your README were left untouched.
