### PR TITLE
support MCP_API_KEY check

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Configuration is done via environment variables. The only command-line argument 
 | `TOOL_FIND_DESCRIPTION`  | Custom description for the find tool                                | See default in [`settings.py`](src/mcp_server_qdrant/settings.py) |
 | `QDRANT_SEARCH_LIMIT`    | Maximum number of results to return from search                     | `10`                                                              |
 | `QDRANT_READ_ONLY`       | Enable read-only mode (disables `qdrant-store` tool)                | `false`                                                           |
+| `MCP_API_KEY`            | Bearer token required to access the `sse`/`streamable-http` transports. Clients must send `Authorization: Bearer <key>`. If unset, no auth check is performed. Ignored for the `stdio` transport. | None |
 
 ### FastMCP Environment Variables
 

--- a/src/mcp_server_qdrant/auth.py
+++ b/src/mcp_server_qdrant/auth.py
@@ -1,0 +1,36 @@
+import secrets
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class BearerAuthMiddleware:
+    """
+    ASGI middleware that requires a matching `Authorization: Bearer <api_key>`
+    header on every HTTP request. Non-HTTP scopes (e.g. lifespan) pass through
+    untouched.
+    """
+
+    def __init__(self, app: ASGIApp, api_key: str):
+        self.app = app
+        self.api_key = api_key
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        auth_header = headers.get(b"authorization", b"").decode("latin-1")
+        token = (
+            auth_header[len("Bearer ") :]
+            if auth_header.startswith("Bearer ")
+            else ""
+        )
+
+        if not token or not secrets.compare_digest(token, self.api_key):
+            response = JSONResponse({"error": "Unauthorized"}, status_code=401)
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/src/mcp_server_qdrant/main.py
+++ b/src/mcp_server_qdrant/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 
 def main():
@@ -21,4 +22,18 @@ def main():
     # only after we make the changes.
     from mcp_server_qdrant.server import mcp
 
-    mcp.run(transport=args.transport)
+    run_kwargs = {}
+    if args.transport != "stdio":
+        # Bearer-token auth only makes sense for the HTTP-based transports.
+        # If MCP_API_KEY isn't set, the server stays open (no auth check).
+        api_key = os.environ.get("MCP_API_KEY")
+        if api_key:
+            from starlette.middleware import Middleware
+
+            from mcp_server_qdrant.auth import BearerAuthMiddleware
+
+            run_kwargs["middleware"] = [
+                Middleware(BearerAuthMiddleware, api_key=api_key)
+            ]
+
+    mcp.run(transport=args.transport, **run_kwargs)


### PR DESCRIPTION
When the MCP server accesses the QDRANT server, a fixed QDRANT_API_KEY needs to be set in the environment variables. At this point, access via MCP is no longer protected.

Therefore, the MCP_API_KEY environment variable is added to the MCP server to ensure that only authorized users can access it.

(All code is generated by Claude, and I tested it.)